### PR TITLE
Implement training routines for neural components

### DIFF
--- a/neuro-ant-optimizer/tests/test_refine_monotonicity.py
+++ b/neuro-ant-optimizer/tests/test_refine_monotonicity.py
@@ -1,4 +1,6 @@
 import numpy as np
+import pytest
+
 from neuro_ant_optimizer.optimizer import NeuroAntPortfolioOptimizer, OptimizationObjective
 from neuro_ant_optimizer.constraints import PortfolioConstraints
 from neuro_ant_optimizer.utils import nearest_psd
@@ -13,4 +15,4 @@ def test_refine_monotonicity():
     cons = PortfolioConstraints(min_weight=0.0, max_weight=0.3, leverage_limit=1.0, equality_enforce=True)
     opt = NeuroAntPortfolioOptimizer(n_assets=n)
     res = opt.optimize(mu, cov, cons, objective=OptimizationObjective.SHARPE_RATIO)
-    assert res.weights.sum() == 1.0(1.0, abs=1e-6)
+    assert res.weights.sum() == pytest.approx(1.0, abs=1e-6)


### PR DESCRIPTION
## Summary
- implement gradient-based training helpers for the risk and pheromone networks with gradient clipping for stability
- fix the refine monotonicity test to use `pytest.approx` so it validates the weight sum without raising a type error

## Testing
- PYTHONPATH=src pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d7788087f883339aa224593ed17554