### PR TITLE
Modernize optimizer components and add policy trainer tests

### DIFF
--- a/neuro-ant-optimizer/src/neuro_ant_optimizer/models.py
+++ b/neuro-ant-optimizer/src/neuro_ant_optimizer/models.py
@@ -1,72 +1,96 @@
 from __future__ import annotations
-import numpy as np
+
+from typing import List, Optional
+
 import torch
 import torch.nn as nn
-from .utils import safe_softmax
+
 
 class BaseNeuralNetwork(nn.Module):
-    def save_model(self, filepath: str) -> None:
-        torch.save(self.state_dict(), filepath)
+    """Adds device/dtype plumbing + simple (de)serialization helpers."""
 
-    def load_model(self, filepath: str) -> None:
-        self.load_state_dict(torch.load(filepath, map_location="cpu"))
-        self.eval()
+    def __init__(
+        self,
+        dtype: torch.dtype = torch.float32,
+        device: Optional[torch.device] = None,
+    ) -> None:
+        super().__init__()
+        self._dtype = dtype
+        self._device = device or torch.device("cpu")
+
+    def to_device(self) -> "BaseNeuralNetwork":
+        return self.to(dtype=self._dtype, device=self._device)
+
+    def save_model(self, path: str) -> None:
+        torch.save(
+            {
+                "state_dict": self.state_dict(),
+                "dtype": self._dtype,
+                "device": str(self._device),
+            },
+            path,
+        )
+
+    def load_model(self, path: str) -> None:
+        blob = torch.load(path, map_location="cpu")
+        self.load_state_dict(blob["state_dict"])
+        self._dtype = blob.get("dtype", torch.float32)
+        self._device = torch.device(blob.get("device", "cpu"))
+        self.to_device().eval()
+
 
 class RiskAssessmentNetwork(BaseNeuralNetwork):
-    def __init__(self, n_assets: int, hidden: list[int] = [96,64,32]):
-        super().__init__()
-        self.n_assets = n_assets
-        in_dim = n_assets * 3
-        self.net = nn.Sequential(
-            nn.Linear(in_dim, hidden[0]), nn.ReLU(), nn.Dropout(0.1),
-            nn.Linear(hidden[0], hidden[1]), nn.ReLU(), nn.Dropout(0.1),
-            nn.Linear(hidden[1], hidden[2]), nn.ReLU(),
-            nn.Linear(hidden[2], n_assets), nn.Sigmoid(),
-        )
+    def __init__(
+        self,
+        n_assets: int,
+        hidden: Optional[List[int]] = None,
+        **kw,
+    ) -> None:
+        super().__init__(**kw)
+        hidden = hidden or [96, 64, 32]  # avoid mutable default
+        dims = [n_assets] + hidden + [n_assets]
+        layers = []
+        for i in range(len(dims) - 1):
+            layers.append(nn.Linear(dims[i], dims[i + 1]))
+            if i < len(dims) - 2:
+                layers.append(nn.ReLU())
+        self.net = nn.Sequential(*layers)
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return self.net(x)
+    def forward(self, x: torch.Tensor) -> torch.Tensor:  # type: ignore[override]
+        return self.net(x.to(self._device, dtype=self._dtype))
 
-    @torch.no_grad()
-    def predict(self, mu: np.ndarray, sigma: np.ndarray, corr: np.ndarray) -> np.ndarray:
-        avg_corr = (corr.sum(axis=1) - 1.0) / max(self.n_assets - 1, 1)
-        feats = np.stack([mu, sigma, avg_corr], axis=1).reshape(-1).astype(np.float32)
-        tens = torch.from_numpy(feats).unsqueeze(0)
-        return self.forward(tens).cpu().numpy().ravel()
 
 class PheromoneNetwork(BaseNeuralNetwork):
-    def __init__(self, n_assets: int, embedding_dim: int = 48):
-        super().__init__()
+    def __init__(
+        self,
+        n_assets: int,
+        embed_dim: int = 48,
+        heads: int = 4,
+        **kw,
+    ) -> None:
+        super().__init__(**kw)
         self.n_assets = n_assets
-        self.asset_embedding = nn.Embedding(n_assets, embedding_dim)
-        self.attn = nn.MultiheadAttention(embedding_dim, num_heads=4, batch_first=True)
-        self.norm = nn.LayerNorm(embedding_dim)
+        self.emb = nn.Embedding(n_assets, embed_dim)
+        self.attn = nn.MultiheadAttention(
+            embed_dim, num_heads=heads, batch_first=True
+        )
+        self.norm = nn.LayerNorm(embed_dim)
         self.ffn = nn.Sequential(
-            nn.Linear(embedding_dim, 96), nn.ReLU(),
-            nn.Linear(96, 48), nn.ReLU(),
-            nn.Linear(48, n_assets * n_assets), nn.Sigmoid()
+            nn.Linear(embed_dim, 96),
+            nn.ReLU(),
+            nn.Linear(96, 48),
+            nn.ReLU(),
+            nn.Linear(48, n_assets),
         )
 
-    def forward(self, asset_indices: torch.Tensor) -> torch.Tensor:
-        emb = self.asset_embedding(asset_indices).unsqueeze(0)
-        attn_out, _ = self.attn(emb, emb, emb)
-        emb = self.norm(emb + attn_out)
-        pooled = emb.mean(dim=1)
-        mat = self.ffn(pooled).view(self.n_assets, self.n_assets)
-        return mat
+    def transition_matrix(self) -> torch.Tensor:
+        idx = torch.arange(self.n_assets, device=self._device)
+        x = self.emb(idx).unsqueeze(0)
+        a, _ = self.attn(x, x, x)
+        h = self.norm(a + x)
+        logits = self.ffn(h)
+        return torch.softmax(logits, dim=-1).squeeze(0).to(dtype=self._dtype)
 
-    @torch.no_grad()
-    def transition_probs(self, current: int, visited: list[int]) -> np.ndarray:
-        idx = torch.arange(self.n_assets, dtype=torch.long)
-        mat = self.forward(idx).cpu().numpy()
-        row = mat[current].copy()
-        mask = np.ones(self.n_assets, dtype=bool)
-        mask[current] = False
-        if visited:
-            mask[visited] = False
-        row = row * mask.astype(float)
-        if row.sum() <= 0:
-            p = np.ones(self.n_assets, dtype=float) * mask.astype(float)
-            s = p.sum()
-            return p / s if s > 0 else np.ones(self.n_assets) / self.n_assets
-        return safe_softmax(row)
+    def forward(self, *_args, **_kw) -> torch.Tensor:  # back-compat
+        return self.transition_matrix()
+

--- a/neuro-ant-optimizer/src/neuro_ant_optimizer/utils.py
+++ b/neuro-ant-optimizer/src/neuro_ant_optimizer/utils.py
@@ -1,22 +1,62 @@
 from __future__ import annotations
+
+from typing import Optional
+
 import numpy as np
-import torch
+
+try:  # soft dependency
+    import torch  # type: ignore
+except Exception:  # pragma: no cover
+    torch = None  # type: ignore
+
+
+def set_seed(seed: int, deterministic_torch: bool = True) -> None:
+    """Set numpy (and torch if present) seeds; prefer deterministic backends."""
+
+    np.random.seed(seed)
+    if torch is None:
+        return
+    import torch as _t  # local alias to avoid type-checkers complaining
+
+    _t.manual_seed(seed)
+    if deterministic_torch:
+        try:
+            _t.use_deterministic_algorithms(True)
+            _t.backends.cudnn.benchmark = False
+            _t.backends.cudnn.deterministic = True
+        except Exception:
+            pass
+
 
 def nearest_psd(cov: np.ndarray, eps: float = 1e-10) -> np.ndarray:
+    """Fast symmetric eigenvalue clip to nearest PSD matrix."""
+
     cov = 0.5 * (cov + cov.T)
-    eigval, eigvec = np.linalg.eigh(cov)
-    eigval_clipped = np.clip(eigval, eps, None)
-    cov_psd = (eigvec * eigval_clipped) @ eigvec.T
-    return 0.5 * (cov_psd + cov_psd.T)
+    w, v = np.linalg.eigh(cov)
+    w = np.clip(w, eps, None)
+    psd = (v * w) @ v.T
+    return 0.5 * (psd + psd.T)
 
-def safe_softmax(x: np.ndarray) -> np.ndarray:
-    x = x - np.max(x)
-    e = np.exp(np.clip(x, -60, 60))
-    s = e.sum()
-    if s <= 0:
-        return np.ones_like(x) / len(x)
-    return e / s
 
-def set_seed(seed: int) -> None:
-    np.random.seed(seed)
-    torch.manual_seed(seed)
+def safe_softmax(
+    x: np.ndarray, axis: int = -1, mask: Optional[np.ndarray] = None
+) -> np.ndarray:
+    """
+    Numerically-stable softmax with optional boolean mask (True=keep).
+    If all entries on an axis are masked or zeroed, returns uniform on unmasked set.
+    """
+
+    x = np.asarray(x, dtype=float)
+    if mask is not None:
+        x = np.where(mask, x, -np.inf)
+    x_max = np.nanmax(x, axis=axis, keepdims=True)
+    z = np.exp(np.clip(x - x_max, -60, 60))
+    if mask is not None:
+        z = np.where(mask, z, 0.0)
+    denom = z.sum(axis=axis, keepdims=True)
+    if np.any(denom == 0):
+        u = np.ones_like(z) if mask is None else mask.astype(float)
+        s = u.sum(axis=axis, keepdims=True)
+        return np.divide(u, np.where(s == 0, 1.0, s), where=True)
+    return z / denom
+

--- a/neuro-ant-optimizer/tests/test_colony_feasibility.py
+++ b/neuro-ant-optimizer/tests/test_colony_feasibility.py
@@ -1,0 +1,16 @@
+import numpy as np
+
+from neuro_ant_optimizer.colony import Ant
+from neuro_ant_optimizer.models import PheromoneNetwork, RiskAssessmentNetwork
+
+
+def test_ant_build_feasible_equalweight():
+    N = 8
+    pn = PheromoneNetwork(N).to_device().eval()
+    rn = RiskAssessmentNetwork(N).to_device().eval()
+    ant = Ant(N)
+    w = ant.build(pn, rn, alpha=1.0, beta=0.2)
+    assert w.shape == (N,)
+    assert abs(w.sum() - 1.0) < 1e-9
+    assert (w >= -1e-12).all()
+

--- a/neuro-ant-optimizer/tests/test_policy_trainer.py
+++ b/neuro-ant-optimizer/tests/test_policy_trainer.py
@@ -1,0 +1,14 @@
+import numpy as np
+
+from neuro_ant_optimizer.models import PheromoneNetwork
+from neuro_ant_optimizer.optimizer import PolicyTrainer
+
+
+def test_policy_trainer_step_runs():
+    N = 6
+    net = PheromoneNetwork(N).to_device()
+    trainer = PolicyTrainer(net)
+    targets = np.stack([np.ones((N, N)) / N for _ in range(4)], axis=0)
+    loss = trainer.step(targets)
+    assert np.isfinite(loss)
+

--- a/neuro-ant-optimizer/tests/test_utils_and_constraints.py
+++ b/neuro-ant-optimizer/tests/test_utils_and_constraints.py
@@ -1,0 +1,28 @@
+import numpy as np
+
+from neuro_ant_optimizer.utils import nearest_psd, safe_softmax, set_seed
+
+
+def test_nearest_psd_eigs_nonnegative():
+    A = np.array([[1.0, 2.0], [3.0, 1.0]])
+    P = nearest_psd(A)
+    w = np.linalg.eigvalsh(0.5 * (P + P.T))
+    assert (w >= -1e-12).all()
+
+
+def test_safe_softmax_mask_axis():
+    x = np.array([[1.0, 2.0, 3.0]])
+    mask = np.array([[True, False, True]])
+    p = safe_softmax(x, axis=-1, mask=mask)
+    assert np.isfinite(p).all()
+    assert abs(p.sum() - 1.0) < 1e-9
+    assert p[0, 1] == 0.0
+
+
+def test_seed_determinism_numpy_only():
+    set_seed(123)
+    a = np.random.rand(5)
+    set_seed(123)
+    b = np.random.rand(5)
+    assert np.allclose(a, b)
+


### PR DESCRIPTION
## Summary
- expand utility helpers with deterministic seeding, PSD projection, and masked softmax support
- refactor neural models, colony construction, and optimizer training hooks to use the new device-aware helpers and policy trainer
- extend the SLSQP refinement path with turnover penalties and add targeted unit tests for utilities, colony feasibility, and the policy trainer

## Testing
- PYTHONPATH=src pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d789a2d09c83338b72a96fe2f55b0c