### PR TITLE
Fix neural network device and dtype detection

### DIFF
--- a/neuro-ant-optimizer/src/neuro_ant_optimizer/colony.py
+++ b/neuro-ant-optimizer/src/neuro_ant_optimizer/colony.py
@@ -30,11 +30,7 @@ class Ant:
         trans = pheromone_net.transition_matrix().detach().cpu().numpy()
         risk = np.ones(n, dtype=float)
         if risk_net is not None:
-            I = torch.eye(
-                n,
-                device=getattr(risk_net, "_device", torch.device("cpu")),
-                dtype=getattr(risk_net, "_dtype", torch.float32),
-            )
+            I = torch.eye(n, device=risk_net.param_device, dtype=risk_net.param_dtype)
             r = risk_net(I).detach().cpu().numpy()
             risk = np.clip(np.diag(r), 1e-6, None)
         self.visited = [int(np.random.randint(0, n))]

--- a/neuro-ant-optimizer/src/neuro_ant_optimizer/optimizer.py
+++ b/neuro-ant-optimizer/src/neuro_ant_optimizer/optimizer.py
@@ -15,7 +15,7 @@ from .models import RiskAssessmentNetwork, PheromoneNetwork
 from .colony import Ant, AntColony
 from .constraints import PortfolioConstraints
 from .refine import refine_slsqp
-from .utils import nearest_psd, safe_softmax, set_seed
+from .utils import nearest_psd, set_seed
 
 logger = logging.getLogger(__name__)
 if not logger.handlers:


### PR DESCRIPTION
## Summary
- add parameter-based helpers so models always reflect their current device and dtype
- use the new helpers in the risk and pheromone networks to avoid stale device bookkeeping
- clean up call sites and remove an unused import

## Testing
- `PYTHONPATH=src pytest -q` *(fails: RuntimeError: element 0 of tensors does not require grad and does not have a grad_fn)*

------
https://chatgpt.com/codex/tasks/task_e_68d7911ab46c833390d1cca9d61cca2b