### PR TITLE
Allow pheromone transition matrix to retain gradients

### DIFF
--- a/neuro-ant-optimizer/src/neuro_ant_optimizer/models.py
+++ b/neuro-ant-optimizer/src/neuro_ant_optimizer/models.py
@@ -98,7 +98,6 @@ class PheromoneNetwork(BaseNeuralNetwork):
             nn.Linear(48, n_assets),
         )
 
-    @torch.no_grad()
     def transition_matrix(self) -> torch.Tensor:
         idx = torch.arange(self.n_assets, device=self.param_device)
         x = self.emb(idx).unsqueeze(0)


### PR DESCRIPTION
## Summary
- remove the `@torch.no_grad()` decorator from `PheromoneNetwork.transition_matrix` so training can track gradients

## Testing
- PYTHONPATH=neuro-ant-optimizer/src pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d79381d2c483338ba93e7e1d3ae83a