### PR TITLE
Optimize pheromone inference and training

### DIFF
--- a/neuro-ant-optimizer/src/neuro_ant_optimizer/colony.py
+++ b/neuro-ant-optimizer/src/neuro_ant_optimizer/colony.py
@@ -20,6 +20,7 @@ class Ant:
         risk_net,
         alpha: float,
         beta: float,
+        trans_matrix: np.ndarray | None = None,
     ) -> np.ndarray:
         """
         Build a tour using pheromone transitions and (optional) risk heuristics.
@@ -27,7 +28,17 @@ class Ant:
         """
 
         n = self.n_assets
-        trans = pheromone_net.transition_matrix().detach().cpu().numpy()
+        if trans_matrix is None:
+            # Inference path: avoid building a grad graph
+            with torch.no_grad():
+                trans = (
+                    pheromone_net.transition_matrix()
+                    .detach()
+                    .cpu()
+                    .numpy()
+                )
+        else:
+            trans = trans_matrix
         risk = np.ones(n, dtype=float)
         if risk_net is not None:
             I = torch.eye(n, device=risk_net.param_device, dtype=risk_net.param_dtype)

--- a/neuro-ant-optimizer/tests/test_pheromone_grads.py
+++ b/neuro-ant-optimizer/tests/test_pheromone_grads.py
@@ -1,0 +1,23 @@
+import torch
+
+from neuro_ant_optimizer.models import PheromoneNetwork
+
+
+def test_pheromone_grads_cpu():
+    net = PheromoneNetwork(5).to("cpu")
+    T = net.transition_matrix()  # should require grad by default
+    loss = (T ** 2).sum()
+    loss.backward()
+    assert any(p.grad is not None for p in net.parameters())
+
+
+def test_device_switch_cuda_if_available():
+    if not torch.cuda.is_available():
+        return
+
+    net = PheromoneNetwork(4).to("cuda")
+    T = net.transition_matrix()
+    assert T.is_cuda
+    loss = T.sum()
+    loss.backward()
+    assert any((p.grad is not None) and p.is_cuda for p in net.parameters())


### PR DESCRIPTION
## Summary
- run pheromone inference with optional cached transition matrices to avoid building grad graphs
- replace BCE pheromone updates with the existing KL+entropy PolicyTrainer and reuse cached transitions per iteration
- add regression tests covering pheromone gradient flow and CUDA device transfers

## Testing
- PYTHONPATH=neuro-ant-optimizer/src pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d7959dce5083338e582be145411f34