### PR TITLE
Add covariance shrinkage option and CVaR objective

### DIFF
--- a/neuro-ant-optimizer/src/neuro_ant_optimizer/utils.py
+++ b/neuro-ant-optimizer/src/neuro_ant_optimizer/utils.py
@@ -38,6 +38,15 @@ def nearest_psd(cov: np.ndarray, eps: float = 1e-10) -> np.ndarray:
     return 0.5 * (psd + psd.T)
 
 
+def shrink_covariance(cov: np.ndarray, delta: float = 0.1) -> np.ndarray:
+    """Simple Ledoit-Wolf-style diagonal shrinkage with optional clipping."""
+
+    delta = float(np.clip(delta, 0.0, 1.0))
+    d = np.diag(np.diag(cov))
+    shrunk = (1.0 - delta) * cov + delta * d
+    return 0.5 * (shrunk + shrunk.T)
+
+
 def safe_softmax(
     x: np.ndarray, axis: int = -1, mask: Optional[np.ndarray] = None
 ) -> np.ndarray:

--- a/neuro-ant-optimizer/tests/test_utils_shrinkage.py
+++ b/neuro-ant-optimizer/tests/test_utils_shrinkage.py
@@ -1,0 +1,19 @@
+import numpy as np
+
+from neuro_ant_optimizer.utils import nearest_psd, shrink_covariance
+
+
+def test_shrink_covariance_basic():
+    rng = np.random.default_rng(0)
+    A = rng.standard_normal((6, 6))
+    cov = 0.5 * (A + A.T) + np.eye(6) * 0.1
+
+    shrunk = shrink_covariance(cov, delta=0.2)
+
+    assert np.allclose(shrunk, shrunk.T, atol=1e-12)
+    assert np.allclose(np.diag(shrunk), np.diag(cov))
+    assert np.all(np.abs(shrunk - np.diag(np.diag(cov))) <= np.abs(cov - np.diag(np.diag(cov))) + 1e-12)
+
+    psd = nearest_psd(shrunk)
+    eigs = np.linalg.eigvalsh(0.5 * (psd + psd.T))
+    assert (eigs >= -1e-12).all()


### PR DESCRIPTION
## Summary
- add a simple shrink_covariance helper for diagonal shrinkage and unit tests
- expose optimizer configuration for shrinkage and CVaR settings and apply shrinkage prior to PSD repair
- add a CVaR minimization objective using a normal approximation to tail loss

## Testing
- PYTHONPATH=neuro-ant-optimizer/src pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d798fdb288833399b9835718ee1fd4