### PR TITLE
Add neuro-ant-backtest CLI entry point and smoke test

### DIFF
--- a/neuro-ant-optimizer/.github/workflows/ci.yml
+++ b/neuro-ant-optimizer/.github/workflows/ci.yml
@@ -18,7 +18,13 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install numpy scipy torch pytest
+          # optional extras for CLI smoke
+          pip install pandas matplotlib
       - name: Run tests
         env:
           PYTHONPATH: neuro-ant-optimizer/src
         run: pytest -q
+      - name: CLI smoke (backtest)
+        run: |
+          neuro-ant-optimizer/src/neuro_ant_optimizer/backtest/backtest.py >/dev/null 2>&1 || true
+          python -c "import sys,subprocess; subprocess.check_call(['neuro-ant-backtest','--csv','neuro-ant-optimizer/backtest/sample_returns.csv','--lookback','5','--step','2','--ewma_span','3','--objective','sharpe','--out','neuro-ant-optimizer/backtest/out_ci'])"

--- a/neuro-ant-optimizer/README.md
+++ b/neuro-ant-optimizer/README.md
@@ -48,3 +48,11 @@ print("Sharpe:", res.sharpe_ratio, "Vol:", res.volatility)
 - `risk_weight`: blend risk heuristic in ant decisions
 - `topk_refine`/`topk_train`: compute & learning budgets per iteration
 - `grad_clip`, `device`, `dtype`
+
+## CLI backtest
+Install optional deps then run:
+```bash
+python -m pip install "neuro-ant-optimizer[backtest]"
+neuro-ant-backtest --csv path/to/returns.csv --lookback 252 --step 21 --ewma_span 60 --objective sharpe --out bt_out
+```
+Outputs `metrics.csv`, `equity.csv`, and (if matplotlib is present) `equity.png`.

--- a/neuro-ant-optimizer/pyproject.toml
+++ b/neuro-ant-optimizer/pyproject.toml
@@ -18,6 +18,10 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = ["pytest>=7.4", "pytest-cov>=4.1", "ruff>=0.5.0", "mypy>=1.10"]
+backtest = ["pandas>=2.0", "matplotlib>=3.7"]
+
+[project.scripts]
+neuro-ant-backtest = "neuro_ant_optimizer.backtest.backtest:main"
 
 [tool.pytest.ini_options]
 addopts = "-q"


### PR DESCRIPTION
## Summary
- add an optional backtest extra and expose the neuro-ant-backtest console script
- document CLI usage in the README
- install extras in CI and add a neuro-ant-backtest smoke check

## Testing
- PYTHONPATH=src python -m neuro_ant_optimizer.backtest.backtest --csv backtest/sample_returns.csv --lookback 5 --step 2 --ewma_span 3 --objective sharpe --out backtest/out_local

------
https://chatgpt.com/codex/tasks/task_e_68d7af8933bc833392a48b4cfcc495f2