### PR TITLE
Add public version attribute and typing marker

### DIFF
--- a/neuro-ant-optimizer/pyproject.toml
+++ b/neuro-ant-optimizer/pyproject.toml
@@ -2,6 +2,13 @@
 requires = ["setuptools>=68", "wheel"]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools.packages.find]
+where = ["src"]
+include = ["neuro_ant_optimizer*"]
+
+[tool.setuptools.package-data]
+neuro_ant_optimizer = ["py.typed"]
+
 [project]
 name = "neuro-ant-optimizer"
 version = "0.3.0"

--- a/neuro-ant-optimizer/src/neuro_ant_optimizer/__init__.py
+++ b/neuro-ant-optimizer/src/neuro_ant_optimizer/__init__.py
@@ -1,15 +1,26 @@
+"""Neuro Ant Optimizer public API."""
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError, version
+
+from .constraints import PortfolioConstraints
 from .optimizer import (
     NeuroAntPortfolioOptimizer,
     OptimizationObjective,
     OptimizationResult,
     OptimizerConfig,
 )
-from .constraints import PortfolioConstraints
 
 __all__ = [
     "NeuroAntPortfolioOptimizer",
+    "OptimizerConfig",
     "OptimizationObjective",
     "OptimizationResult",
-    "OptimizerConfig",
     "PortfolioConstraints",
+    "__version__",
 ]
+
+try:  # runtime package version
+    __version__ = version("neuro-ant-optimizer")
+except PackageNotFoundError:  # editable/dev env
+    __version__ = "0.0.0+local"

--- a/neuro-ant-optimizer/src/neuro_ant_optimizer/py.typed
+++ b/neuro-ant-optimizer/src/neuro_ant_optimizer/py.typed
@@ -1,0 +1,1 @@
+# Marker file to indicate this package ships type information (PEP 561).

--- a/neuro-ant-optimizer/tests/test_version.py
+++ b/neuro-ant-optimizer/tests/test_version.py
@@ -1,0 +1,5 @@
+def test_version_string_present():
+    import neuro_ant_optimizer as nao
+
+    assert isinstance(nao.__version__, str)
+    assert len(nao.__version__) > 0


### PR DESCRIPTION
## Summary
- expose the runtime package version via `neuro_ant_optimizer.__version__`
- declare bundled typing information and ship the `py.typed` marker file
- cover the version export with a lightweight regression test

## Testing
- PYTHONPATH=src python -c "import neuro_ant_optimizer as nao; print(nao.__version__)"
- PYTHONPATH=src pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d7b2520e788333b920489beb1ac489