### PR TITLE
Add repo shim so CLI works without PYTHONPATH

### DIFF
--- a/neuro-ant-optimizer/.github/workflows/ci.yml
+++ b/neuro-ant-optimizer/.github/workflows/ci.yml
@@ -22,8 +22,6 @@ jobs:
           # optional extras for CLI smoke
           pip install pandas matplotlib
       - name: Run tests
-        env:
-          PYTHONPATH: neuro-ant-optimizer/src
         run: pytest -q
       - name: Ruff (lint)
         run: |

--- a/neuro-ant-optimizer/README.md
+++ b/neuro-ant-optimizer/README.md
@@ -53,17 +53,42 @@ print("Sharpe:", res.sharpe_ratio, "Vol:", res.volatility)
 Install optional deps then run:
 ```bash
 python -m pip install "neuro-ant-optimizer[backtest]"
-neuro-ant-backtest --csv path/to/returns.csv --lookback 252 --step 21 --ewma_span 60 --objective sharpe --out bt_out --save-weights
+neuro-ant-backtest --csv path/to/returns.csv --lookback 252 --step 21 --ewma_span 60 \
+  --objective sharpe --out bt_out --save-weights --tx-cost-bps 5 --tx-cost-mode upfront
+# tx-cost-mode: upfront | amortized | posthoc | none
+# writes metrics.csv (incl. sortino, cvar), equity.csv, equity_net_of_tc.csv (if posthoc), and weights.csv
 ```
+Behavior summary
+
+--tx-cost-mode upfront → costs applied inside the loop on the first day of each block.
+
+--tx-cost-mode amortized → costs applied inside the loop evenly across the block.
+
+--tx-cost-mode posthoc → no costs during loop; after the run, we create equity_net_of_tc.csv with amortized costs.
+
+--tx-cost-mode none → no costs at all.
+
 Outputs `metrics.csv`, `equity.csv`, and (if matplotlib is present) `equity.png`.
+
+## Testing
+From the repository root:
+
+```bash
+pytest -q
+```
+
+The test harness in `tests/conftest.py` automatically adds `neuro-ant-optimizer/src`
+to `sys.path`, so no manual `PYTHONPATH` configuration or editable install is required.
+
 ## Offline usage (no install)
 If your environment blocks package downloads:
 ```bash
-# Run the CLI module directly via PYTHONPATH
-PYTHONPATH=neuro-ant-optimizer/src \
+# Run the CLI module directly from the repo checkout
 python -m neuro_ant_optimizer.backtest \
   --csv neuro-ant-optimizer/backtest/sample_returns.csv \
   --lookback 5 --step 2 --ewma_span 3 --objective sharpe --out neuro-ant-optimizer/backtest/out_local
+# The repo includes a lightweight shim (neuro_ant_optimizer/__init__.py) that
+# delegates to src/neuro_ant_optimizer so no PYTHONPATH edits are needed.
 ```
 
 ## Offline wheel build & install

--- a/neuro-ant-optimizer/neuro_ant_optimizer/__init__.py
+++ b/neuro-ant-optimizer/neuro_ant_optimizer/__init__.py
@@ -1,0 +1,27 @@
+"""Development helper to expose the package without installation."""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+_repo_root = Path(__file__).resolve().parent.parent
+_src_pkg = _repo_root / "src" / "neuro_ant_optimizer"
+
+if not _src_pkg.exists():  # pragma: no cover - safety guard
+    raise ImportError("neuro_ant_optimizer source package not found")
+
+spec = importlib.util.spec_from_file_location(
+    __name__,
+    _src_pkg / "__init__.py",
+    submodule_search_locations=[str(_src_pkg)],
+)
+if spec is None or spec.loader is None:  # pragma: no cover - defensive
+    raise ImportError("Unable to load neuro_ant_optimizer package")
+
+module = importlib.util.module_from_spec(spec)
+sys.modules[__name__] = module
+spec.loader.exec_module(module)
+
+# Mirror attributes into this module's namespace so direct imports work.
+globals().update(module.__dict__)

--- a/neuro-ant-optimizer/tests/conftest.py
+++ b/neuro-ant-optimizer/tests/conftest.py
@@ -1,0 +1,17 @@
+"""
+Ensure `neuro_ant_optimizer` is importable when running pytest from the repo root
+without setting PYTHONPATH or doing an editable install.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve()
+_PKG_ROOT = _HERE.parents[1]   # neuro-ant-optimizer/
+_SRC = _PKG_ROOT / "src"
+
+if _SRC.is_dir():
+    p = str(_SRC)
+    if p not in sys.path:
+        sys.path.insert(0, p)


### PR DESCRIPTION
## Summary
- extend the backtest engine with configurable transaction-cost timing, additional portfolio metrics, and richer weight exports
- surface CLI flags for the new behaviours and document usage, including asset names and rebalance dates in saved outputs
- update README guidance on transaction-cost modes and resulting artifacts
- ensure pytest discovers the package without manual PYTHONPATH tweaks and align CI/docs accordingly
- add a repository-level shim so `python -m neuro_ant_optimizer.backtest` works from a fresh checkout and note the workflow in the README

## Testing
- pytest -q
- python -m neuro_ant_optimizer.backtest --csv backtest/sample_returns.csv --lookback 5 --step 2 --ewma_span 3 --objective sharpe --out /tmp/bt_posthoc_noenv --tx-cost-bps 5 --tx-cost-mode posthoc
- python -m neuro_ant_optimizer.backtest --csv backtest/sample_returns.csv --lookback 5 --step 2 --ewma_span 3 --objective sharpe --out /tmp/bt_upfront_weights --tx-cost-bps 5 --tx-cost-mode upfront --save-weights


------
https://chatgpt.com/codex/tasks/task_e_68d7b82ddf808333b4dbaf640cad2c07