### PR TITLE
Preserve CSV headers in pandas-free backtest path

### DIFF
--- a/neuro-ant-optimizer/tests/test_backtest_minimal_csv.py
+++ b/neuro-ant-optimizer/tests/test_backtest_minimal_csv.py
@@ -1,0 +1,23 @@
+from importlib import import_module
+from pathlib import Path
+
+import numpy as np
+
+bt = import_module("neuro_ant_optimizer.backtest.backtest")
+
+
+def test_read_csv_without_pandas(monkeypatch):
+    csv_path = Path("backtest/sample_returns.csv")
+    monkeypatch.setattr(bt, "pd", None)
+
+    frame = bt._read_csv(csv_path)
+    data = frame.to_numpy()
+
+    assert data.shape[1] == 4
+    assert np.issubdtype(data.dtype, np.floating)
+    np.testing.assert_allclose(
+        data[0],
+        np.array([0.001, 0.0, -0.001, 0.002]),
+    )
+    assert frame.columns == ["A", "B", "C", "D"]
+    assert frame.index[0] == np.datetime64("2020-01-01")


### PR DESCRIPTION
## Summary
- preserve asset column headers when parsing CSVs without pandas so downstream exports match the source data
- expose the fallback frame columns attribute and cover the no-pandas path with a regression test

## Testing
- pytest -q
- python -m neuro_ant_optimizer.backtest --csv backtest/sample_returns.csv --lookback 5 --step 2 --ewma_span 3 --objective sharpe --out /tmp/bt_posthoc --tx-cost-bps 5 --tx-cost-mode posthoc
- python -m neuro_ant_optimizer.backtest --csv backtest/sample_returns.csv --lookback 5 --step 2 --ewma_span 3 --objective sharpe --out /tmp/bt_upfront --tx-cost-bps 5 --tx-cost-mode upfront --save-weights
- python -m neuro_ant_optimizer.backtest --csv backtest/sample_returns.csv --lookback 5 --step 2 --ewma_span 3 --objective sharpe --out /tmp/bt_amortized --tx-cost-bps 5 --tx-cost-mode amortized --save-weights

------
https://chatgpt.com/codex/tasks/task_e_68d7c98a566c8333a2db52a82e877d8e