### PR TITLE
Harden pandas-free backtest CSV handling

### DIFF
--- a/neuro-ant-optimizer/tests/test_backtest_minimal_csv.py
+++ b/neuro-ant-optimizer/tests/test_backtest_minimal_csv.py
@@ -1,0 +1,23 @@
+from importlib import import_module
+from pathlib import Path
+
+import numpy as np
+
+bt = import_module("neuro_ant_optimizer.backtest.backtest")
+
+
+def test_read_csv_without_pandas(monkeypatch):
+    csv_path = Path("backtest/sample_returns.csv")
+    monkeypatch.setattr(bt, "pd", None)
+
+    frame = bt._read_csv(csv_path)
+    data = frame.to_numpy()
+
+    assert data.shape[1] == 4
+    assert np.issubdtype(data.dtype, np.floating)
+    np.testing.assert_allclose(
+        data[0],
+        np.array([0.001, 0.0, -0.001, 0.002]),
+    )
+    assert frame.columns == ["A", "B", "C", "D"]
+    assert frame.index[0] == np.datetime64("2020-01-01")

--- a/neuro-ant-optimizer/tests/test_backtest_weights_no_pandas.py
+++ b/neuro-ant-optimizer/tests/test_backtest_weights_no_pandas.py
@@ -1,0 +1,27 @@
+from importlib import import_module
+from pathlib import Path
+
+import numpy as np
+
+
+backtest = import_module("neuro_ant_optimizer.backtest.backtest")
+
+
+def test_write_weights_without_pandas(tmp_path, monkeypatch):
+    monkeypatch.setattr(backtest, "pd", None)
+    results = {
+        "weights": np.array(
+            [[0.25, 0.25, 0.25, 0.25], [0.4, 0.3, 0.2, 0.1]],
+            dtype=float,
+        ),
+        "rebalance_dates": ["2020-01-06", "2020-01-08"],
+        "asset_names": ["A", "B", "C", "D"],
+    }
+    out_path = Path(tmp_path) / "weights.csv"
+    backtest._write_weights(out_path, results)
+
+    contents = out_path.read_text().strip().splitlines()
+    header = contents[0].lstrip("# ").split(",")
+    assert header == ["date", "A", "B", "C", "D"]
+    assert contents[1].startswith("2020-01-06,")
+    assert contents[2].startswith("2020-01-08,")


### PR DESCRIPTION
## Summary
- guard the pandas-free weights writer against 1D arrays and header mismatches, falling back to synthetic names when needed
- strip BOM/whitespace noise when parsing CSV headers without pandas and align extracted names to the data
- add a regression test that exercises the pandas-free weights export path

## Testing
- pytest -q
- PYTHONNOUSERSITE=1 PYTHONPATH=neuro-ant-optimizer/src python - <<'PY'\nimport importlib\n\nbt = importlib.import_module("neuro_ant_optimizer.backtest.backtest")\nbt.pd = None\nbt.main([\n  "--csv","neuro-ant-optimizer/backtest/sample_returns.csv",\n  "--lookback","5","--step","2","--ewma_span","3",\n  "--objective","sharpe","--out","/tmp/bt_no_pandas",\n  "--tx-cost-bps","5","--tx-cost-mode","posthoc","--save-weights"\n])\nprint("OK")\nPY
- python - <<'PY'\nimport csv\np="/tmp/bt_no_pandas/weights.csv"\nwith open(p) as f:\n    r=csv.reader(f)\n    hdr=next(r)\nprint("weights header:", hdr)\nassert hdr[0]=="date" and hdr[1:]==["A","B","C","D"]\nPY

------
https://chatgpt.com/codex/tasks/task_e_68d7c98a566c8333a2db52a82e877d8e