### PR TITLE
Add audit reporting, config manifests, and CI polish

### DIFF
--- a/neuro-ant-optimizer/.github/workflows/ci.yml
+++ b/neuro-ant-optimizer/.github/workflows/ci.yml
@@ -4,10 +4,11 @@ on:
   pull_request:
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: ["ubuntu-latest", "macos-latest"]
         python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
@@ -17,22 +18,44 @@ jobs:
       - name: Install deps (minimal CPU)
         run: |
           python -m pip install --upgrade pip
-          pip install numpy scipy torch pytest
+          pip install numpy scipy torch pytest pytest-cov build
           pip install ruff mypy
           # optional extras for CLI smoke
           pip install pandas matplotlib
       - name: Run tests
-        run: pytest -q
+        run: |
+          if [ "${{ matrix.os }}" = "ubuntu-latest" ] && [ "${{ matrix.python-version }}" = "3.11" ]; then
+            pytest --cov=neuro_ant_optimizer --cov-report=xml --cov-report=html --cov-fail-under=85
+          else
+            pytest -q
+          fi
+      - name: Upload coverage HTML
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-html-${{ matrix.python-version }}-${{ matrix.os }}
+          path: htmlcov
       - name: Ruff (lint)
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
         run: |
           ruff --version
           ruff check neuro-ant-optimizer/src neuro-ant-optimizer/tests
       - name: mypy (types)
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
         env:
           MYPYPATH: neuro-ant-optimizer/src
         run: |
           mypy neuro-ant-optimizer/src
       - name: CLI smoke (backtest)
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
         run: |
           neuro-ant-optimizer/src/neuro_ant_optimizer/backtest/backtest.py >/dev/null 2>&1 || true
           python -c "import sys,subprocess; subprocess.check_call(['neuro-ant-backtest','--csv','neuro-ant-optimizer/backtest/sample_returns.csv','--lookback','5','--step','2','--ewma_span','3','--objective','sharpe','--out','neuro-ant-optimizer/backtest/out_ci'])"
+      - name: Build wheel
+        run: |
+          python -m build --wheel
+      - name: Upload wheel artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheel-${{ matrix.os }}-py${{ matrix.python-version }}
+          path: dist/*.whl

--- a/neuro-ant-optimizer/backtest/plot_equity.py
+++ b/neuro-ant-optimizer/backtest/plot_equity.py
@@ -1,0 +1,94 @@
+"""Utility script to visualize backtest equity curves with optional overlays."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Iterable, List, Tuple
+
+import numpy as np
+
+try:  # pragma: no cover - optional dependency
+    import pandas as pd  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - allow minimal envs
+    pd = None  # type: ignore
+
+
+def _load_equity(csv_path: Path) -> Tuple[List[object], np.ndarray]:
+    if not csv_path.exists():
+        raise FileNotFoundError(f"Missing equity file: {csv_path}")
+    if pd is not None:
+        frame = pd.read_csv(csv_path)
+        if "date" not in frame or "equity" not in frame:
+            raise ValueError(f"CSV {csv_path} must contain 'date' and 'equity' columns")
+        dates = frame["date"].tolist()
+        equity = frame["equity"].to_numpy(dtype=float)
+        return dates, equity
+
+    raw = np.genfromtxt(csv_path, delimiter=",", names=True, dtype=None, encoding="utf-8")
+    if raw.size == 0:
+        return [], np.asarray([], dtype=float)
+    if "date" not in raw.dtype.names or "equity" not in raw.dtype.names:
+        raise ValueError(f"CSV {csv_path} must contain 'date' and 'equity' columns")
+    dates = raw["date"].tolist() if raw.ndim == 0 else raw["date"].tolist()
+    equity = np.asarray(raw["equity"], dtype=float)
+    return dates, equity
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Plot equity curves from backtest output")
+    parser.add_argument("--dir", type=str, required=True, help="Directory containing equity CSVs")
+    parser.add_argument(
+        "--out",
+        type=str,
+        default=None,
+        help="Destination PNG path (defaults to <dir>/equity_overlay.png)",
+    )
+    parser.add_argument(
+        "--overlay",
+        action="store_true",
+        help="Overlay gross, net-of-tx, and net-of-slippage curves when available",
+    )
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    out_dir = Path(args.dir)
+    if not out_dir.exists():
+        raise FileNotFoundError(f"Output directory not found: {out_dir}")
+
+    base_path = out_dir / "equity.csv"
+    dates, gross_curve = _load_equity(base_path)
+    overlays: List[Tuple[str, np.ndarray]] = [("gross", gross_curve)]
+
+    if args.overlay:
+        tc_path = out_dir / "equity_net_of_tc.csv"
+        if tc_path.exists():
+            _, tc_curve = _load_equity(tc_path)
+            overlays.append(("net tx", tc_curve))
+        slip_path = out_dir / "equity_net_of_slippage.csv"
+        if slip_path.exists():
+            _, slip_curve = _load_equity(slip_path)
+            overlays.append(("net slippage", slip_curve))
+
+    try:  # pragma: no cover - plotting dependency
+        import matplotlib.pyplot as plt
+
+        plt.figure()
+        for label, curve in overlays:
+            if curve.size:
+                plt.plot(dates, curve, label=label)
+        plt.xlabel("Date")
+        plt.ylabel("Equity")
+        plt.title("Equity Curves")
+        if len(overlays) > 1:
+            plt.legend()
+        plt.tight_layout()
+        out_path = Path(args.out) if args.out else out_dir / "equity_overlay.png"
+        plt.savefig(out_path, dpi=160)
+        plt.close()
+        print(f"Saved {out_path}")
+    except ModuleNotFoundError as exc:  # pragma: no cover - minimal envs
+        raise RuntimeError("matplotlib is required for plotting") from exc
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI guard
+    main()

--- a/neuro-ant-optimizer/tests/test_backtest_config_manifest.py
+++ b/neuro-ant-optimizer/tests/test_backtest_config_manifest.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import json
+from importlib import import_module
+from pathlib import Path
+
+import numpy as np
+
+bt = import_module("neuro_ant_optimizer.backtest.backtest")
+
+
+class _StubOptimizer:
+    def __init__(self, weight: np.ndarray):
+        self.weight = weight
+        self.cfg = type("Cfg", (), {"use_shrinkage": False, "shrinkage_delta": 0.0})()
+
+    def optimize(self, *_, **__):
+
+        class _Result:
+            def __init__(self, w: np.ndarray):
+                self.weights = w
+
+        return _Result(self.weight)
+
+
+def test_config_overrides_and_manifest(tmp_path: Path, monkeypatch) -> None:
+    returns_path = tmp_path / "returns.csv"
+    returns_path.write_text(
+        "date,A,B\n"
+        "2020-01-01,0.01,0.00\n"
+        "2020-01-02,0.02,-0.01\n"
+        "2020-01-03,0.00,0.01\n"
+        "2020-01-04,0.01,0.02\n"
+        "2020-01-05,0.02,0.01\n"
+        "2020-01-06,0.00,0.03\n"
+    )
+
+    out_dir = tmp_path / "bt_out"
+    config_path = tmp_path / "run.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                f"csv: {returns_path}",
+                "lookback: 4",
+                "step: 3",
+                "seed: 11",
+                f"out: {out_dir}",
+                "objective: sharpe",
+                "tx_cost_bps: 0",
+                "refine_every: 2",
+            ]
+        )
+    )
+
+    stub = _StubOptimizer(np.array([0.6, 0.4], dtype=float))
+    monkeypatch.setattr(bt, "_build_optimizer", lambda n_assets, seed: stub)
+
+    bt.main(["--config", str(config_path), "--lookback", "5"])
+
+    manifest_path = out_dir / "run_config.json"
+    assert manifest_path.exists()
+    manifest = json.loads(manifest_path.read_text())
+    assert manifest["args"]["lookback"] == 5
+    assert manifest["args"]["csv"] == str(returns_path)
+    assert manifest["args"]["refine_every"] == 2
+    assert manifest["config_path"] == str(config_path)
+    assert "package_version" in manifest
+    assert "python_version" in manifest

--- a/neuro-ant-optimizer/tests/test_backtest_rebalance_report.py
+++ b/neuro-ant-optimizer/tests/test_backtest_rebalance_report.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from importlib import import_module
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+bt = import_module("neuro_ant_optimizer.backtest.backtest")
+
+
+class _Frame:
+    def __init__(self, arr: np.ndarray, dates: np.ndarray, cols: list[str]):
+        self._arr = arr
+        self._idx = list(dates)
+        self._cols = cols
+
+    def to_numpy(self, dtype=float):
+        return self._arr.astype(dtype)
+
+    @property
+    def index(self):  # pragma: no cover - simple accessor
+        return self._idx
+
+    @property
+    def columns(self):  # pragma: no cover - simple accessor
+        return self._cols
+
+
+class _StubOptimizer:
+    def __init__(self, weights_seq: list[np.ndarray]):
+        self.weights_seq = weights_seq
+        self.calls = 0
+        self.cfg = type("Cfg", (), {"use_shrinkage": False, "shrinkage_delta": 0.0})()
+
+    def optimize(self, *_, **__):
+        weights = self.weights_seq[self.calls]
+        self.calls += 1
+
+        class _Result:
+            def __init__(self, w: np.ndarray):
+                self.weights = w
+
+        return _Result(weights)
+
+
+def test_rebalance_report_and_net_returns(tmp_path: Path, monkeypatch) -> None:
+    n_periods = 12
+    dates = np.array(
+        [np.datetime64("2020-01-01") + np.timedelta64(i, "D") for i in range(n_periods)]
+    )
+    returns = np.array(
+        [
+            [0.01, 0.0],
+            [0.02, -0.01],
+            [0.0, 0.01],
+            [0.03, 0.01],
+            [0.02, 0.0],
+            [0.01, 0.02],
+            [0.0, -0.01],
+            [0.01, 0.03],
+            [0.0, 0.02],
+            [0.02, 0.01],
+            [0.01, -0.02],
+            [0.03, 0.0],
+        ],
+        dtype=float,
+    )
+    frame = _Frame(returns, dates, ["A", "B"])
+
+    weights_seq = [
+        np.array([0.6, 0.4], dtype=float),
+        np.array([0.5, 0.5], dtype=float),
+        np.array([0.7, 0.3], dtype=float),
+    ]
+    stub = _StubOptimizer(weights_seq)
+    monkeypatch.setattr(bt, "_build_optimizer", lambda n_assets, seed: stub)
+
+    results = bt.backtest(
+        frame,
+        lookback=3,
+        step=3,
+        seed=0,
+        tx_cost_bps=10.0,
+        tx_cost_mode="posthoc",
+    )
+
+    records = results["rebalance_records"]
+    assert len(records) == 3
+
+    tc = 10.0 / 1e4
+    for idx, record in enumerate(records):
+        start = 3 + 3 * idx
+        stop = start + 3
+        block = returns[start:stop]
+        w = weights_seq[idx]
+        gross = block @ w
+        expected_turn = float(np.abs(w).sum()) if idx == 0 else float(np.abs(w - weights_seq[idx - 1]).sum())
+        expected_gross = float(np.prod(1.0 + gross) - 1.0)
+        tx_block = gross - (tc * expected_turn / max(1, gross.size))
+        expected_net_tx = float(np.prod(1.0 + tx_block) - 1.0)
+
+        assert record["turnover"] == pytest.approx(expected_turn)
+        assert record["tx_cost"] == pytest.approx(tc * expected_turn)
+        assert record["gross_ret"] == pytest.approx(expected_gross)
+        assert record["net_tx_ret"] == pytest.approx(expected_net_tx)
+        assert record["net_slip_ret"] == pytest.approx(expected_net_tx)
+        assert record["sector_breaches"] == 0
+        assert record["factor_inf_norm"] == pytest.approx(0.0)
+
+    # Ensure per-period net returns align with report calculations
+    np.testing.assert_allclose(
+        results["gross_returns"],
+        np.concatenate([(returns[3:6] @ weights_seq[0]), (returns[6:9] @ weights_seq[1]), (returns[9:12] @ weights_seq[2])]),
+    )
+
+    report_path = tmp_path / "rebalance_report.csv"
+    bt._write_rebalance_report(report_path, results)
+    text = report_path.read_text().splitlines()
+    assert text[0].startswith("date,gross_ret,net_tx_ret")
+

--- a/neuro-ant-optimizer/tests/test_backtest_refine_every.py
+++ b/neuro-ant-optimizer/tests/test_backtest_refine_every.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from importlib import import_module
+
+import numpy as np
+
+bt = import_module("neuro_ant_optimizer.backtest.backtest")
+
+
+class _TrackingOptimizer:
+    def __init__(self, weights_seq: list[np.ndarray]):
+        self.weights_seq = weights_seq
+        self.calls = 0
+        self.refine_flags: list[bool] = []
+        self.cfg = type("Cfg", (), {"use_shrinkage": False, "shrinkage_delta": 0.0})()
+
+    def optimize(self, *_, refine: bool = True, **__):
+        self.refine_flags.append(refine)
+        weights = self.weights_seq[self.calls]
+        self.calls += 1
+
+        class _Result:
+            def __init__(self, w: np.ndarray):
+                self.weights = w
+
+        return _Result(weights)
+
+
+def test_refine_every_skips(monkeypatch) -> None:
+    n_periods = 15
+    dates = np.array(
+        [np.datetime64("2021-01-01") + np.timedelta64(i, "D") for i in range(n_periods)]
+    )
+    returns = np.tile(np.array([[0.01, 0.0], [0.0, 0.01], [0.02, -0.01], [0.0, 0.02], [0.01, 0.0]], dtype=float), (3, 1))
+    returns = returns[:n_periods]
+
+    class _Frame:
+        def __init__(self, arr: np.ndarray):
+            self._arr = arr
+            self._idx = list(dates)
+            self._cols = ["A", "B"]
+
+        def to_numpy(self, dtype=float):
+            return self._arr.astype(dtype)
+
+        @property
+        def index(self):  # pragma: no cover - simple accessor
+            return self._idx
+
+        @property
+        def columns(self):  # pragma: no cover - simple accessor
+            return self._cols
+
+    frame = _Frame(returns)
+    weights_seq = [np.array([0.5, 0.5], dtype=float) for _ in range(4)]
+    tracker = _TrackingOptimizer(weights_seq)
+    monkeypatch.setattr(bt, "_build_optimizer", lambda n_assets, seed: tracker)
+
+    bt.backtest(frame, lookback=3, step=3, refine_every=2)
+
+    assert tracker.refine_flags == [True, False, True, False]


### PR DESCRIPTION
## Summary
- extend the backtest CLI with config file support, run manifests, and per-rebalance reporting with exposure exports
- add deterministic ant sampling tweaks, gated refinements, and equity overlay tooling
- expand CI with coverage enforcement, wheel artifacts, and macOS coverage along with new regression tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d80dd2135883339dc48eeff93a1dc3