### PR TITLE
Add pluggable covariance models

### DIFF
--- a/neuro-ant-optimizer/src/neuro_ant_optimizer/__init__.py
+++ b/neuro-ant-optimizer/src/neuro_ant_optimizer/__init__.py
@@ -3,6 +3,11 @@ from __future__ import annotations
 
 from importlib.metadata import PackageNotFoundError, version
 
+try:  # runtime package version
+    __version__ = version("neuro-ant-optimizer")
+except PackageNotFoundError:  # editable/dev env
+    __version__ = "0.0.0+local"
+
 from .constraints import PortfolioConstraints
 from .optimizer import (
     BenchmarkStats,
@@ -11,6 +16,7 @@ from .optimizer import (
     OptimizationResult,
     OptimizerConfig,
 )
+from .backtest.backtest import ewma_cov
 
 __all__ = [
     "NeuroAntPortfolioOptimizer",
@@ -20,9 +26,5 @@ __all__ = [
     "PortfolioConstraints",
     "BenchmarkStats",
     "__version__",
+    "ewma_cov",
 ]
-
-try:  # runtime package version
-    __version__ = version("neuro-ant-optimizer")
-except PackageNotFoundError:  # editable/dev env
-    __version__ = "0.0.0+local"

--- a/neuro-ant-optimizer/tests/test_cov_models.py
+++ b/neuro-ant-optimizer/tests/test_cov_models.py
@@ -1,0 +1,53 @@
+import numpy as np
+from importlib import import_module
+
+
+bt = import_module("neuro_ant_optimizer.backtest.backtest")
+
+
+def _is_psd(m):
+    # Numerical PSD check
+    w = np.linalg.eigvalsh(0.5 * (m + m.T))
+    return np.all(w > -1e-10)
+
+
+def test_cov_backends_psd_and_shapes():
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(200, 8))
+    S = bt._sample_cov(X)
+    E = bt.ewma_cov(X, span=20)
+    LW = bt._lw_cov(X)
+    OAS = bt._oas_cov(X)
+    for M in (S, E, LW, OAS):
+        assert M.shape == (8, 8)
+        assert _is_psd(M)
+
+
+def test_backtest_cov_model_routes():
+    rng = np.random.default_rng(1)
+    T, N = 40, 4
+    ret = rng.normal(scale=0.01, size=(T, N))
+    dates = [np.datetime64("2020-01-01") + np.timedelta64(i, "D") for i in range(T)]
+
+    class _Frame:
+        def __init__(self, a, d):
+            self._a = a
+            self._d = d
+            self._c = [f"A{i}" for i in range(a.shape[1])]
+
+        def to_numpy(self, dtype=float):
+            return self._a.astype(dtype)
+
+        @property
+        def index(self):
+            return self._d
+
+        @property
+        def columns(self):
+            return self._c
+
+    F = _Frame(ret, dates)
+    for model in ("sample", "ewma", "lw", "oas"):
+        res = bt.backtest(F, lookback=10, step=5, cov_model=model, ewma_span=5, seed=7)
+        assert res["cov_model"] == model
+        assert len(res["equity"]) > 0


### PR DESCRIPTION
## Summary
- add sample, Ledoit–Wolf, and OAS covariance helpers alongside the existing EWMA backend
- expose a --cov-model option in the backtester to choose the covariance estimator and plumb the selection through results
- cover the covariance implementations and routing logic with regression tests

## Testing
- pytest -q tests/test_cov_models.py

------
https://chatgpt.com/codex/tasks/task_e_68d81ce1cf00833383605d151a631d4d