### PR TITLE
Harden covariance selector and add determinism test

### DIFF
--- a/neuro-ant-optimizer/README.md
+++ b/neuro-ant-optimizer/README.md
@@ -57,8 +57,10 @@ CLI backtest
 Install optional deps then run:
 
 python -m pip install "neuro-ant-optimizer[backtest]"
-neuro-ant-backtest --csv path/to/returns.csv --lookback 252 --step 21 --ewma_span 60 \
-  --objective sharpe --out bt_out --save-weights --tx-cost-bps 5 --tx-cost-mode upfront
+neuro-ant-backtest --csv path/to/returns.csv --lookback 252 --step 21 \
+  --objective sharpe --cov-model lw --out bt_out \
+  --save-weights --tx-cost-bps 5 --tx-cost-mode upfront
+# --cov-model: sample | ewma (use --ewma_span) | lw | oas
 # tx-cost-mode: upfront | amortized | posthoc | none
 # writes metrics.csv (incl. sortino, cvar), equity.csv, equity_net_of_tc.csv (if posthoc), and weights.csv
 Behavior summary

--- a/neuro-ant-optimizer/tests/test_cov_determinism.py
+++ b/neuro-ant-optimizer/tests/test_cov_determinism.py
@@ -1,0 +1,38 @@
+from importlib import import_module
+
+import numpy as np
+
+
+bt = import_module("neuro_ant_optimizer.backtest.backtest")
+
+
+class _Frame:
+    def __init__(self, arr, dates, cols):
+        self._a = arr
+        self._d = dates
+        self._c = cols
+
+    def to_numpy(self, dtype=float):
+        return self._a.astype(dtype)
+
+    @property
+    def index(self):
+        return self._d
+
+    @property
+    def columns(self):
+        return self._c
+
+
+def test_cov_model_determinism():
+    rng = np.random.default_rng(0)
+    n, m = 160, 6
+    X = rng.normal(size=(n, m))
+    dates = [np.datetime64("2022-01-01") + np.timedelta64(i, "D") for i in range(n)]
+    cols = [f"A{i}" for i in range(m)]
+    frame = _Frame(X, dates, cols)
+
+    r1 = bt.backtest(frame, lookback=40, step=10, cov_model="oas", seed=7)
+    r2 = bt.backtest(frame, lookback=40, step=10, cov_model="oas", seed=7)
+
+    np.testing.assert_allclose(r1["equity"], r2["equity"], rtol=0, atol=0)


### PR DESCRIPTION
## Summary
- validate covariance model arguments, ignore stray EWMA spans for other models, and require spans of at least two
- key the covariance cache by model parameters to avoid collisions and expand the LRU, keeping behavior deterministic
- document the --cov-model flag in the README and add a determinism regression test

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d81f94fd98833389dc9cb647738fcc