### PR TITLE
Add factor validation diagnostics and docs

### DIFF
--- a/neuro-ant-optimizer/examples/configs/daily_oas.yaml
+++ b/neuro-ant-optimizer/examples/configs/daily_oas.yaml
@@ -1,0 +1,17 @@
+# Daily factor-neutral run with strict alignment
+csv: data/returns_daily.csv
+benchmark_csv: data/benchmark_sp500.csv
+factors: data/factors_style.csv
+lookback: 252
+step: 21
+cov_model: oas
+objective: sharpe
+refine_every: 1
+seed: 7
+factor_align: strict
+factors_required: true
+factor_tolerance: 1e-6
+tx_cost_bps: 3
+tx_cost_mode: amortized
+slippage: proportional:5
+out: runs/daily_oas

--- a/neuro-ant-optimizer/examples/configs/minimal.yaml
+++ b/neuro-ant-optimizer/examples/configs/minimal.yaml
@@ -1,0 +1,10 @@
+# Minimal run without factors
+csv: data/returns.csv
+lookback: 126
+step: 21
+objective: max_return
+cov_model: sample
+refine_every: 1
+seed: 3
+skip_plot: true
+out: runs/minimal

--- a/neuro-ant-optimizer/examples/configs/weekly_subset.yaml
+++ b/neuro-ant-optimizer/examples/configs/weekly_subset.yaml
@@ -1,0 +1,17 @@
+# Weekly rebalance allowing factor gaps (logged in factor_diagnostics.json)
+csv: data/returns_weekly.csv
+factors: data/factors_weekly.csv
+lookback: 260
+step: 5
+cov_model: lw
+objective: sharpe
+refine_every: 2
+seed: 11
+factor_align: subset
+factors_required: false
+factor_tolerance: 5e-6
+tx_cost_bps: 5
+tx_cost_mode: posthoc
+slippage: square:1.5
+skip_plot: true
+out: runs/weekly_subset

--- a/neuro-ant-optimizer/tests/test_backtest_rebalance_report.py
+++ b/neuro-ant-optimizer/tests/test_backtest_rebalance_report.py
@@ -107,6 +107,7 @@ def test_rebalance_report_and_net_returns(tmp_path: Path, monkeypatch) -> None:
         assert record["net_slip_ret"] == pytest.approx(expected_net_tx)
         assert record["sector_breaches"] == 0
         assert record["factor_inf_norm"] == pytest.approx(0.0)
+        assert record["factor_missing"] is False
 
     # Ensure per-period net returns align with report calculations
     np.testing.assert_allclose(
@@ -117,5 +118,8 @@ def test_rebalance_report_and_net_returns(tmp_path: Path, monkeypatch) -> None:
     report_path = tmp_path / "rebalance_report.csv"
     bt._write_rebalance_report(report_path, results)
     text = report_path.read_text().splitlines()
-    assert text[0].startswith("date,gross_ret,net_tx_ret")
+    assert text[0] == (
+        "date,gross_ret,net_tx_ret,net_slip_ret,turnover,tx_cost,slippage_cost,"
+        "sector_breaches,factor_inf_norm,factor_missing"
+    )
 

--- a/neuro-ant-optimizer/tests/test_cov_determinism.py
+++ b/neuro-ant-optimizer/tests/test_cov_determinism.py
@@ -36,3 +36,4 @@ def test_cov_model_determinism():
     r2 = bt.backtest(frame, lookback=40, step=10, cov_model="oas", seed=7)
 
     np.testing.assert_allclose(r1["equity"], r2["equity"], rtol=0, atol=0)
+    assert r1["rebalance_records"] == r2["rebalance_records"]

--- a/neuro-ant-optimizer/tests/test_factor_validation.py
+++ b/neuro-ant-optimizer/tests/test_factor_validation.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from neuro_ant_optimizer.backtest.backtest import (
+    FactorPanel,
+    backtest,
+    validate_factor_panel,
+    validate_factor_targets,
+)
+
+
+class _Frame:
+    def __init__(self, arr: np.ndarray, dates: list[np.datetime64], cols: list[str]):
+        self._arr = arr
+        self._dates = dates
+        self._cols = cols
+
+    def to_numpy(self, dtype=float):  # pragma: no cover - simple proxy
+        return self._arr.astype(dtype)
+
+    @property
+    def index(self):  # pragma: no cover - simple accessor
+        return self._dates
+
+    @property
+    def columns(self):  # pragma: no cover - simple accessor
+        return self._cols
+
+
+def _simple_panel(
+    dates: list[np.datetime64],
+    assets: list[str],
+    loadings: np.ndarray,
+) -> FactorPanel:
+    factor_names = [f"F{i}" for i in range(loadings.shape[2])]
+    return FactorPanel(dates=list(dates), assets=list(assets), loadings=loadings, factor_names=factor_names)
+
+
+def test_factor_schema_strict_ok() -> None:
+    dates = [np.datetime64("2020-01-01") + np.timedelta64(i, "D") for i in range(4)]
+    extra_date = np.datetime64("2020-01-10")
+    returns = np.random.default_rng(0).normal(scale=0.01, size=(4, 3))
+    frame = _Frame(returns, dates, ["A", "B", "C"])
+
+    panel_dates = dates + [extra_date]
+    loadings = np.ones((5, 2, 2), dtype=float)
+    panel = _simple_panel(panel_dates, ["A", "B"], loadings)
+
+    aligned, diagnostics = validate_factor_panel(panel, frame, align="strict")
+    assert aligned.assets == ["A", "B"]
+    assert aligned.dates == dates
+    assert diagnostics.dropped_assets == ["C"]
+    assert diagnostics.dropped_date_count == 1
+    assert diagnostics.missing_window_count == 0
+
+
+def test_factor_schema_strict_fail() -> None:
+    dates = [np.datetime64("2020-01-01") + np.timedelta64(i, "D") for i in range(3)]
+    returns = np.random.default_rng(1).normal(scale=0.01, size=(3, 2))
+    frame = _Frame(returns, dates, ["A", "B"])
+
+    panel_dates = dates[:-1]
+    loadings = np.ones((len(panel_dates), 2, 1), dtype=float)
+    panel = _simple_panel(panel_dates, ["A", "B"], loadings)
+
+    with pytest.raises(ValueError):
+        validate_factor_panel(panel, frame, align="strict")
+
+
+def test_factor_schema_subset_warn() -> None:
+    dates = [np.datetime64("2021-01-01") + np.timedelta64(i, "D") for i in range(4)]
+    returns = np.random.default_rng(2).normal(scale=0.01, size=(4, 2))
+    frame = _Frame(returns, dates, ["A", "B"])
+
+    panel_dates = dates[:-1]
+    loadings = np.ones((len(panel_dates), 2, 2), dtype=float)
+    panel = _simple_panel(panel_dates, ["A", "B"], loadings)
+
+    aligned, diagnostics = validate_factor_panel(panel, frame, align="subset")
+    assert aligned.dates == panel_dates
+    assert diagnostics.missing_window_count == 1
+    assert diagnostics.to_dict()["missing_rebalance_dates"][0].startswith("2021-01-04")
+
+
+def test_factor_targets_validation_mismatch_name_and_len() -> None:
+    with pytest.raises(ValueError):
+        validate_factor_targets(np.ones(2), ["X", "Y", "Z"])
+
+
+def test_backtest_factors_required_hard_fail_on_gap() -> None:
+    rng = np.random.default_rng(5)
+    n_periods = 12
+    dates = [np.datetime64("2022-01-01") + np.timedelta64(i, "D") for i in range(n_periods)]
+    returns = rng.normal(scale=0.01, size=(n_periods, 3))
+    frame = _Frame(returns, dates, ["A", "B", "C"])
+
+    # Factors miss the final rebalance date
+    factor_dates = dates[:-1]
+    loadings = rng.normal(scale=0.2, size=(len(factor_dates), 3, 2))
+    panel = _simple_panel(factor_dates, ["A", "B", "C"], loadings)
+
+    with pytest.raises(ValueError):
+        backtest(
+            frame,
+            lookback=4,
+            step=4,
+            factors=panel,
+            factor_align="subset",
+            factors_required=True,
+        )
+
+
+def test_backtest_speed_smoke() -> None:
+    rng = np.random.default_rng(7)
+    n_periods, n_assets = 80, 5
+    returns = rng.normal(scale=0.01, size=(n_periods, n_assets))
+    dates = [np.datetime64("2019-01-01") + np.timedelta64(i, "D") for i in range(n_periods)]
+    frame = _Frame(returns, dates, [f"A{i}" for i in range(n_assets)])
+
+    result_one = backtest(frame, lookback=20, step=5, cov_model="oas", seed=11)
+    result_two = backtest(frame, lookback=20, step=5, cov_model="oas", seed=11)
+
+    np.testing.assert_allclose(result_one["equity"], result_two["equity"], rtol=0, atol=0)
+    assert result_one["rebalance_records"] == result_two["rebalance_records"]
+    assert result_one["factor_diagnostics"] is None


### PR DESCRIPTION
## Summary
- add factor panel preflight validation, diagnostics reporting, and support for strict vs subset alignment modes
- optimize the rolling backtest loop (covariance cache keys, preallocated arrays, vectorized sector tracking) and extend the CLI with new factor flags and diagnostics output
- document factor inputs with runnable configs and add regression tests covering validation, determinism, and CLI behaviour

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d82564406c83338a8f29f4aaab154f