### PR TITLE
Add active exposure constraints and diagnostics

### DIFF
--- a/neuro-ant-optimizer/src/neuro_ant_optimizer/constraints.py
+++ b/neuro-ant-optimizer/src/neuro_ant_optimizer/constraints.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 
@@ -17,6 +17,13 @@ class PortfolioConstraints:
     factor_loadings: Optional[np.ndarray] = None
     factor_targets: Optional[np.ndarray] = None
     factor_tolerance: float = 1e-6
+    benchmark_weights: Optional[np.ndarray] = None
+    min_active_weight: float = float("-inf")
+    max_active_weight: float = float("inf")
+    active_group_map: Optional[List[int]] = None
+    active_group_bounds: Optional[Dict[int, Tuple[float, float]]] = None
+    factor_lower_bounds: Optional[np.ndarray] = None
+    factor_upper_bounds: Optional[np.ndarray] = None
 
     def factors_enabled(self) -> bool:
         if self.factor_loadings is None or self.factor_targets is None:
@@ -26,3 +33,24 @@ class PortfolioConstraints:
         if loadings.ndim != 2 or targets.ndim != 1:
             return False
         return loadings.shape[1] == targets.shape[0]
+
+    def factor_bounds_enabled(self) -> bool:
+        if self.factor_loadings is None:
+            return False
+        lower = self.factor_lower_bounds
+        upper = self.factor_upper_bounds
+        if lower is None and upper is None:
+            return False
+        loadings = np.asarray(self.factor_loadings)
+        if loadings.ndim != 2:
+            return False
+        n_factors = loadings.shape[1]
+        if lower is not None:
+            lower_arr = np.asarray(lower)
+            if lower_arr.ndim != 1 or lower_arr.shape[0] != n_factors:
+                return False
+        if upper is not None:
+            upper_arr = np.asarray(upper)
+            if upper_arr.ndim != 1 or upper_arr.shape[0] != n_factors:
+                return False
+        return True

--- a/neuro-ant-optimizer/tests/test_active_constraints.py
+++ b/neuro-ant-optimizer/tests/test_active_constraints.py
@@ -1,0 +1,84 @@
+import numpy as np
+
+from neuro_ant_optimizer.constraints import PortfolioConstraints
+from neuro_ant_optimizer.optimizer import NeuroAntPortfolioOptimizer
+
+
+def test_apply_constraints_respects_active_bounds():
+    n = 5
+    benchmark = np.ones(n, dtype=float) / n
+    opt = NeuroAntPortfolioOptimizer(n_assets=n)
+    constraints = PortfolioConstraints(
+        min_weight=0.0,
+        max_weight=0.7,
+        leverage_limit=1.0,
+        equality_enforce=True,
+        benchmark_weights=benchmark,
+        min_active_weight=-0.05,
+        max_active_weight=0.05,
+    )
+    weights = np.linspace(0.0, 1.0, num=n, dtype=float)
+    adjusted = opt._apply_constraints(weights, constraints)
+    active = adjusted - benchmark
+    assert np.all(active <= constraints.max_active_weight + 1e-8)
+    assert np.all(active >= constraints.min_active_weight - 1e-8)
+    assert abs(adjusted.sum() - 1.0) < 1e-8
+    assert opt._feasible(adjusted, constraints)
+
+
+def test_active_group_bounds_projection():
+    n = 4
+    benchmark = np.array([0.4, 0.3, 0.2, 0.1], dtype=float)
+    opt = NeuroAntPortfolioOptimizer(n_assets=n)
+    constraints = PortfolioConstraints(
+        min_weight=0.0,
+        max_weight=0.6,
+        leverage_limit=1.0,
+        equality_enforce=True,
+        benchmark_weights=benchmark,
+        min_active_weight=-0.2,
+        max_active_weight=0.2,
+        active_group_map=[0, 0, 1, 1],
+        active_group_bounds={0: (-0.05, 0.05), 1: (-0.1, 0.1)},
+    )
+    weights = np.array([0.7, 0.2, 0.05, 0.05], dtype=float)
+    adjusted = opt._apply_constraints(weights, constraints)
+    groups = np.asarray(constraints.active_group_map)
+    active = adjusted - benchmark
+    group_zero = active[groups == 0].sum()
+    group_one = active[groups == 1].sum()
+    assert group_zero <= 0.05 + 1e-8 and group_zero >= -0.05 - 1e-8
+    assert group_one <= 0.1 + 1e-8 and group_one >= -0.1 - 1e-8
+    assert opt._feasible(adjusted, constraints)
+
+
+def test_factor_bounds_enforced_without_targets():
+    n = 3
+    opt = NeuroAntPortfolioOptimizer(n_assets=n)
+    loadings = np.array(
+        [
+            [1.0, 0.0],
+            [0.5, 1.0],
+            [0.0, 0.5],
+        ],
+        dtype=float,
+    )
+    lower = np.array([-0.1, 0.2], dtype=float)
+    upper = np.array([0.2, 0.4], dtype=float)
+    constraints = PortfolioConstraints(
+        min_weight=0.0,
+        max_weight=0.8,
+        leverage_limit=1.0,
+        equality_enforce=True,
+        factor_loadings=loadings,
+        factor_lower_bounds=lower,
+        factor_upper_bounds=upper,
+        factor_tolerance=1e-6,
+    )
+    weights = np.array([0.9, 0.05, 0.05], dtype=float)
+    adjusted = opt._apply_constraints(weights, constraints)
+    exposures = loadings.T @ adjusted
+    assert np.all(exposures <= upper + 1e-6)
+    assert np.all(exposures >= lower - 1e-6)
+    assert opt._feasible(adjusted, constraints)
+

--- a/neuro-ant-optimizer/tests/test_backtest_rebalance_report.py
+++ b/neuro-ant-optimizer/tests/test_backtest_rebalance_report.py
@@ -106,6 +106,7 @@ def test_rebalance_report_and_net_returns(tmp_path: Path, monkeypatch) -> None:
         assert record["net_tx_ret"] == pytest.approx(expected_net_tx)
         assert record["net_slip_ret"] == pytest.approx(expected_net_tx)
         assert record["sector_breaches"] == 0
+        assert record["active_breaches"] == 0
         assert record["factor_inf_norm"] == pytest.approx(0.0)
         assert record["factor_missing"] is False
 
@@ -120,6 +121,6 @@ def test_rebalance_report_and_net_returns(tmp_path: Path, monkeypatch) -> None:
     text = report_path.read_text().splitlines()
     assert text[0] == (
         "date,gross_ret,net_tx_ret,net_slip_ret,turnover,tx_cost,slippage_cost,"
-        "sector_breaches,factor_inf_norm,factor_missing"
+        "sector_breaches,active_breaches,factor_inf_norm,factor_missing"
     )
 


### PR DESCRIPTION
## Summary
- add benchmark-relative active weight bounds, group caps, and factor bound support in the portfolio optimizer
- surface active breach diagnostics in the rebalance report and propagate active constraints to SLSQP refinement
- introduce targeted tests covering active box constraints and report output expectations

## Testing
- pytest tests/test_active_constraints.py tests/test_backtest_rebalance_report.py

------
https://chatgpt.com/codex/tasks/task_e_68d82bcfb0e88333a0eaf557d1755622