### PR TITLE
Improve constraint caching and determinism

### DIFF
--- a/neuro-ant-optimizer/tests/test_cov_determinism.py
+++ b/neuro-ant-optimizer/tests/test_cov_determinism.py
@@ -2,6 +2,11 @@ from importlib import import_module
 
 import numpy as np
 
+from neuro_ant_optimizer.backtest.backtest import (
+    _write_equity,
+    _write_metrics,
+    _write_weights,
+)
 
 bt = import_module("neuro_ant_optimizer.backtest.backtest")
 
@@ -37,3 +42,48 @@ def test_cov_model_determinism():
 
     np.testing.assert_allclose(r1["equity"], r2["equity"], rtol=0, atol=0)
     assert r1["rebalance_records"] == r2["rebalance_records"]
+
+
+def test_report_csv_determinism_with_benchmark(tmp_path):
+    rng = np.random.default_rng(4)
+    n, m = 120, 4
+    returns = rng.normal(scale=0.01, size=(n, m))
+    benchmark = rng.normal(scale=0.008, size=n)
+    dates = [np.datetime64("2021-01-01") + np.timedelta64(i, "D") for i in range(n)]
+    cols = [f"A{i}" for i in range(m)]
+    frame = _Frame(returns, dates, cols)
+    bench_frame = _Frame(benchmark.reshape(-1, 1), dates, ["bench"])
+
+    res1 = bt.backtest(
+        frame,
+        lookback=40,
+        step=10,
+        cov_model="sample",
+        seed=11,
+        benchmark=bench_frame,
+    )
+    res2 = bt.backtest(
+        frame,
+        lookback=40,
+        step=10,
+        cov_model="sample",
+        seed=11,
+        benchmark=bench_frame,
+    )
+
+    out1 = tmp_path / "run1"
+    out2 = tmp_path / "run2"
+    out1.mkdir()
+    out2.mkdir()
+
+    _write_equity(out1 / "equity.csv", res1)
+    _write_equity(out2 / "equity.csv", res2)
+    _write_metrics(out1 / "metrics.csv", res1)
+    _write_metrics(out2 / "metrics.csv", res2)
+    _write_weights(out1 / "weights.csv", res1)
+    _write_weights(out2 / "weights.csv", res2)
+
+    for name in ["equity.csv", "metrics.csv", "weights.csv"]:
+        data1 = (out1 / name).read_bytes()
+        data2 = (out2 / name).read_bytes()
+        assert data1 == data2


### PR DESCRIPTION
## Summary
- add a constraint workspace cache so benchmark alignment, group masks, and factor matrices are reused across projection and SLSQP refinement
- tighten the projection routine to reapply active and factor constraints after turnover while sharing the cached bounds
- cache PSD covariances by window hash and add tests covering near-singular repairs, turnover + active caps, and deterministic report files

## Testing
- pytest tests/test_active_constraints.py tests/test_cov_determinism.py

------
https://chatgpt.com/codex/tasks/task_e_68d84364307c8333aee513988f600abc