### PR TITLE
Handle no-rebalance runs and add optional parquet exports

### DIFF
--- a/neuro-ant-optimizer/README.md
+++ b/neuro-ant-optimizer/README.md
@@ -125,10 +125,11 @@ head -n 5 /tmp/te/rebalance_report.csv
 head -n 20 /tmp/te/metrics.csv
 ```
 
-If the rebalance report is missing after a successful run, the most common reason is that
-**no rebalances were executed** (e.g., the dataset is shorter than the `--lookback` window).
-Decrease the lookback or supply a longer history so the optimizer can evaluate at least
-one block.
+If the dataset is shorter than the configured `--lookback`, the CLI still emits
+`rebalance_report.csv` (header only) so downstream tools do not fail. In that case,
+inspect `run_config.json` for `"warnings": ["no_rebalances"]` to confirm the guardrail
+was triggered. Provide a longer history or decrease the lookback to produce rebalance
+windows.
 
 ---
 

--- a/neuro-ant-optimizer/tests/test_backtest_config_manifest.py
+++ b/neuro-ant-optimizer/tests/test_backtest_config_manifest.py
@@ -68,6 +68,7 @@ def test_config_overrides_and_manifest(tmp_path: Path, monkeypatch) -> None:
     assert manifest["args"]["csv"] == str(returns_path)
     assert manifest["args"]["refine_every"] == 2
     assert manifest["config_path"] == str(config_path)
+    assert manifest["schema_version"] == bt.SCHEMA_VERSION
     assert "package_version" in manifest
     assert "python_version" in manifest
     assert "resolved_constraints" in manifest

--- a/neuro-ant-optimizer/tests/test_no_rebalances.py
+++ b/neuro-ant-optimizer/tests/test_no_rebalances.py
@@ -1,0 +1,60 @@
+import argparse
+import json
+from importlib import import_module
+from pathlib import Path
+
+import numpy as np
+
+bt = import_module("neuro_ant_optimizer.backtest.backtest")
+
+
+class _Frame:
+    def __init__(self, arr: np.ndarray, cols: list[str]):
+        self._arr = arr
+        self._cols = cols
+
+    def to_numpy(self, dtype=float):
+        return self._arr.astype(dtype)
+
+    @property
+    def index(self):  # pragma: no cover - simple accessor
+        return list(range(self._arr.shape[0]))
+
+    @property
+    def columns(self):  # pragma: no cover - simple accessor
+        return self._cols
+
+
+def test_backtest_emits_warning_and_header_only_report(tmp_path: Path) -> None:
+    arr = np.zeros((10, 3), dtype=float)
+    frame = _Frame(arr, ["A", "B", "C"])
+
+    results = bt.backtest(frame, lookback=252, step=21)
+
+    assert results["warnings"] == ["no_rebalances"]
+    assert results["rebalance_records"] == []
+    assert results["returns"].size == 0
+
+    report_path = tmp_path / "rebalance_report.csv"
+    bt._write_rebalance_report(report_path, results)
+    lines = [line for line in report_path.read_text().splitlines() if line]
+    assert len(lines) == 1
+    assert lines[0].startswith("date,")
+
+    manifest_args = argparse.Namespace(
+        csv="returns.csv",
+        lookback=252,
+        out="bt_out",
+        out_format="csv",
+        save_weights=False,
+    )
+    bt._write_run_manifest(
+        tmp_path,
+        manifest_args,
+        config_path=None,
+        results=results,
+        extras=None,
+    )
+    manifest = json.loads((tmp_path / "run_config.json").read_text())
+    assert manifest["warnings"] == ["no_rebalances"]
+    assert manifest["schema_version"] == bt.SCHEMA_VERSION

--- a/neuro-ant-optimizer/tests/test_out_parquet.py
+++ b/neuro-ant-optimizer/tests/test_out_parquet.py
@@ -1,0 +1,71 @@
+import argparse
+import csv
+import json
+from importlib import import_module
+from pathlib import Path
+
+bt = import_module("neuro_ant_optimizer.backtest.backtest")
+
+
+class _DummyFrame:
+    def __init__(self, rows: list[list[str]]):
+        self._rows = rows
+
+    def to_parquet(self, path: Path) -> None:
+        Path(path).write_text(json.dumps({"rows": len(self._rows)}))
+
+
+class _DummyPandas:
+    def read_csv(self, path: Path):  # pragma: no cover - simple helper
+        with Path(path).open(newline="") as fh:
+            reader = csv.reader(fh)
+            rows = list(reader)[1:]
+        return _DummyFrame(rows)
+
+
+def _write_csv(path: Path, header: list[str], rows: list[list[str]]) -> None:
+    with path.open("w", newline="") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(header)
+        for row in rows:
+            writer.writerow(row)
+
+
+def test_parquet_outputs_created_when_requested(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(bt, "pd", _DummyPandas())
+
+    equity_csv = tmp_path / "equity.csv"
+    _write_csv(
+        equity_csv,
+        ["date", "equity", "ret"],
+        [["2020-01-01", "1.0", "0.0"], ["2020-01-02", "1.1", "0.1"]],
+    )
+    rebalance_csv = tmp_path / "rebalance_report.csv"
+    _write_csv(
+        rebalance_csv,
+        ["date", "gross_ret", "net_tx_ret", "net_slip_ret", "turnover", "tx_cost", "slippage_cost", "sector_breaches", "active_breaches", "group_breaches", "factor_bound_breaches", "factor_inf_norm", "factor_missing", "first_violation", "feasible", "projection_iterations", "block_sharpe", "block_sortino", "block_info_ratio", "block_tracking_error"],
+        [["2020-01-02", "0.01", "0.01", "0.01", "0.1", "0.0", "0.0", "0", "0", "0", "0", "0", "False", "", "True", "0", "0.0", "0.0", "", ""]],
+    )
+    metrics_csv = tmp_path / "metrics.csv"
+    _write_csv(metrics_csv, ["metric", "value"], [["sharpe", "0.0"]])
+    weights_csv = tmp_path / "weights.csv"
+    _write_csv(weights_csv, ["date", "w0", "w1"], [["2020-01-02", "0.5", "0.5"]])
+
+    args = argparse.Namespace(out_format="parquet", save_weights=True)
+    bt._maybe_write_parquet(tmp_path, args)
+
+    equity_meta = json.loads((tmp_path / "equity.parquet").read_text())
+    rebalance_meta = json.loads((tmp_path / "rebalance_report.parquet").read_text())
+    metrics_meta = json.loads((tmp_path / "metrics.parquet").read_text())
+    weights_meta = json.loads((tmp_path / "weights.parquet").read_text())
+
+    def _count_rows(csv_path: Path) -> int:
+        with csv_path.open(newline="") as fh:
+            reader = csv.reader(fh)
+            next(reader, None)
+            return sum(1 for _ in reader)
+
+    assert equity_meta["rows"] == _count_rows(equity_csv)
+    assert rebalance_meta["rows"] == _count_rows(rebalance_csv)
+    assert metrics_meta["rows"] == _count_rows(metrics_csv)
+    assert weights_meta["rows"] == _count_rows(weights_csv)


### PR DESCRIPTION
## Summary
- guard backtests with insufficient history by returning empty results, warning, and always writing the rebalance report
- record schema_version/warnings in run_config.json and add an --out-format flag with optional parquet artifacts
- document the guardrail and add tests covering warning propagation and parquet conversion

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d8f33cc8648333aac827c4569de603