### PR TITLE
Add CLI entrypoint to replay backtests

### DIFF
--- a/neuro-ant-optimizer/backtest/reproduce.py
+++ b/neuro-ant-optimizer/backtest/reproduce.py
@@ -1,0 +1,4 @@
+from neuro_ant_optimizer.backtest.reproduce import main
+
+if __name__ == "__main__":
+    main()

--- a/neuro-ant-optimizer/src/neuro_ant_optimizer/backtest/__init__.py
+++ b/neuro-ant-optimizer/src/neuro_ant_optimizer/backtest/__init__.py
@@ -1,5 +1,12 @@
 """Backtesting utilities for the neuro-ant optimizer."""
 
-from .backtest import backtest, main, ewma_cov, max_drawdown, turnover
+from .backtest import backtest, build_parser, ewma_cov, main, max_drawdown, turnover
 
-__all__ = ["backtest", "main", "ewma_cov", "max_drawdown", "turnover"]
+__all__ = [
+    "backtest",
+    "build_parser",
+    "main",
+    "ewma_cov",
+    "max_drawdown",
+    "turnover",
+]

--- a/neuro-ant-optimizer/src/neuro_ant_optimizer/backtest/backtest.py
+++ b/neuro-ant-optimizer/src/neuro_ant_optimizer/backtest/backtest.py
@@ -2262,7 +2262,9 @@ def _read_csv(csv_path: Path):
     return _Frame(values, dates, header_cols)
 
 
-def main(args: Optional[Iterable[str]] = None) -> None:
+def build_parser() -> argparse.ArgumentParser:
+    """Construct the argument parser for the backtest CLI."""
+
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--config",
@@ -2427,6 +2429,12 @@ def main(args: Optional[Iterable[str]] = None) -> None:
         default=1,
         help="Run SLSQP refinement every k rebalances",
     )
+
+    return parser
+
+
+def main(args: Optional[Iterable[str]] = None) -> None:
+    parser = build_parser()
 
     preliminary, _ = parser.parse_known_args(args=args)
     config_path: Optional[Path] = None

--- a/neuro-ant-optimizer/src/neuro_ant_optimizer/backtest/reproduce.py
+++ b/neuro-ant-optimizer/src/neuro_ant_optimizer/backtest/reproduce.py
@@ -1,0 +1,89 @@
+"""Utilities for replaying a backtest run from a saved manifest."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import List, Mapping, MutableMapping, Sequence
+
+from .backtest import build_parser, main as backtest_main
+
+
+def _ensure_mapping(data: Mapping[str, object]) -> MutableMapping[str, object]:
+    return dict(data)
+
+
+def _load_manifest(path: Path) -> MutableMapping[str, object]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, Mapping):
+        raise ValueError("Manifest must be a JSON object")
+    if "args" not in payload:
+        raise ValueError("Manifest is missing 'args' block")
+    args_blob = payload["args"]
+    if not isinstance(args_blob, Mapping):
+        raise ValueError("Manifest 'args' section must be a mapping")
+    manifest = _ensure_mapping(payload)
+    manifest["args"] = _ensure_mapping(args_blob)
+    return manifest
+
+
+def _stringify(value: object) -> str:
+    if isinstance(value, (Path,)):
+        return str(value)
+    return str(value)
+
+
+def _build_cli_from_manifest(
+    parser: argparse.ArgumentParser,
+    manifest_args: Mapping[str, object],
+    out_path: Path,
+) -> List[str]:
+    args_dict = dict(manifest_args)
+    args_dict["out"] = str(out_path)
+
+    cli: List[str] = []
+    store_true = getattr(argparse, "_StoreTrueAction")
+    store_false = getattr(argparse, "_StoreFalseAction")
+
+    for action in parser._actions:
+        if not action.option_strings:
+            continue
+        dest = action.dest
+        if dest is None or dest == argparse.SUPPRESS:
+            continue
+        if dest not in args_dict:
+            continue
+        value = args_dict[dest]
+        if isinstance(action, store_true):
+            if value:
+                cli.append(action.option_strings[-1])
+            continue
+        if isinstance(action, store_false):
+            if not value:
+                cli.append(action.option_strings[-1])
+            continue
+        if value is None:
+            continue
+        option = action.option_strings[-1]
+        cli.extend([option, _stringify(value)])
+    return cli
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Replay a backtest run from its manifest")
+    parser.add_argument("--manifest", required=True, type=Path, help="Path to run_config.json")
+    parser.add_argument("--out", required=True, type=Path, help="Output directory for the replay")
+    parsed = parser.parse_args(argv)
+
+    manifest = _load_manifest(parsed.manifest)
+    manifest_args = manifest["args"]  # type: ignore[index]
+    assert isinstance(manifest_args, Mapping)
+
+    backtest_parser = build_parser()
+    cli_args = _build_cli_from_manifest(backtest_parser, manifest_args, parsed.out)
+    backtest_main(cli_args)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI guard
+    main()


### PR DESCRIPTION
## Summary
- factor out the backtest argument parser into a reusable helper
- add a reproduce CLI that rebuilds the original CLI arguments from a run manifest and reruns the backtest
- expose the new entrypoint via python -m neuro_ant_optimizer.backtest.reproduce

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d8fb54f2b083338d9f8aa680cedf3d