### PR TITLE
Add CLI determinism regression test and CI job

### DIFF
--- a/neuro-ant-optimizer/.github/workflows/ci.yml
+++ b/neuro-ant-optimizer/.github/workflows/ci.yml
@@ -3,6 +3,20 @@ on:
   push: { branches: [ "**" ] }
   pull_request:
 jobs:
+  determinism:
+    name: blessed determinism
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install deps (determinism)
+        run: |
+          python -m pip install --upgrade pip
+          pip install numpy scipy torch pandas matplotlib pytest
+      - name: Run determinism audit
+        run: pytest tests/test_backtest_cli_determinism.py
   test:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/neuro-ant-optimizer/tests/test_backtest_cli_determinism.py
+++ b/neuro-ant-optimizer/tests/test_backtest_cli_determinism.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from neuro_ant_optimizer.backtest.backtest import main as backtest_main
+
+
+def _run_cli(out_dir: Path) -> None:
+    csv_path = Path("backtest/sample_returns.csv")
+    args = [
+        "--csv",
+        str(csv_path),
+        "--lookback",
+        "5",
+        "--step",
+        "2",
+        "--cov-model",
+        "sample",
+        "--objective",
+        "sharpe",
+        "--seed",
+        "123",
+        "--rf-bps",
+        "50",
+        "--out",
+        str(out_dir),
+        "--save-weights",
+        "--skip-plot",
+    ]
+    backtest_main(args)
+
+
+def test_backtest_cli_determinism(tmp_path: Path) -> None:
+    first_out = tmp_path / "run1"
+    second_out = tmp_path / "run2"
+
+    _run_cli(first_out)
+    _run_cli(second_out)
+
+    for artifact in ("equity.csv", "rebalance_report.csv", "weights.csv"):
+        first_bytes = (first_out / artifact).read_bytes()
+        second_bytes = (second_out / artifact).read_bytes()
+        assert first_bytes == second_bytes, f"{artifact} mismatch"


### PR DESCRIPTION
## Summary
- add an end-to-end CLI determinism regression test that runs the backtest twice and compares key artifacts byte-for-byte
- introduce a dedicated "blessed determinism" GitHub Actions job pinned to Ubuntu + Python 3.11

## Testing
- pytest tests/test_backtest_cli_determinism.py

------
https://chatgpt.com/codex/tasks/task_e_68d8fe38a91c8333aff71772eb037c20