### PR TITLE
Add baseline overlays to backtest CLI

### DIFF
--- a/neuro-ant-optimizer/tests/test_backtest_baseline.py
+++ b/neuro-ant-optimizer/tests/test_backtest_baseline.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+from neuro_ant_optimizer.backtest.backtest import main
+
+
+def _write_returns_csv(path: Path, returns: np.ndarray, assets: list[str], dates: list[np.datetime64]) -> None:
+    header = "date," + ",".join(assets)
+    rows = [header]
+    for idx, date in enumerate(dates):
+        row_vals = ",".join(f"{returns[idx, j]:.6f}" for j in range(returns.shape[1]))
+        rows.append(f"{str(date)},{row_vals}")
+    path.write_text("\n".join(rows), encoding="utf-8")
+
+
+def test_backtest_cli_baseline_equal(tmp_path: Path) -> None:
+    rng = np.random.default_rng(0)
+    n_periods, n_assets = 32, 4
+    returns = rng.normal(scale=0.01, size=(n_periods, n_assets))
+    dates = [np.datetime64("2021-01-01") + np.timedelta64(i, "D") for i in range(n_periods)]
+    assets = [f"A{i}" for i in range(n_assets)]
+
+    returns_path = tmp_path / "returns_equal.csv"
+    _write_returns_csv(returns_path, returns, assets, dates)
+
+    out_dir = tmp_path / "baseline_equal"
+    main(
+        [
+            "--csv",
+            str(returns_path),
+            "--lookback",
+            "12",
+            "--step",
+            "5",
+            "--baseline",
+            "equal",
+            "--skip-plot",
+            "--out",
+            str(out_dir),
+        ]
+    )
+
+    metrics_path = out_dir / "metrics.csv"
+    baseline_equity = out_dir / "equity_baseline_equal.csv"
+    equity_plot = out_dir / "equity.png"
+
+    assert metrics_path.exists()
+    assert baseline_equity.exists()
+    assert not equity_plot.exists()
+
+    metrics_text = metrics_path.read_text(encoding="utf-8")
+    assert "baseline_sharpe" in metrics_text
+    assert "hit_rate_vs_baseline" in metrics_text
+
+
+def test_backtest_cli_baseline_cap(tmp_path: Path) -> None:
+    rng = np.random.default_rng(1)
+    n_periods, n_assets = 28, 3
+    returns = rng.normal(scale=0.008, size=(n_periods, n_assets))
+    dates = [np.datetime64("2022-01-01") + np.timedelta64(i, "D") for i in range(n_periods)]
+    assets = [f"A{i}" for i in range(n_assets)]
+
+    returns_path = tmp_path / "returns_cap.csv"
+    _write_returns_csv(returns_path, returns, assets, dates)
+
+    weights_path = tmp_path / "weights_cap.csv"
+    weight_rows = ["asset,weight"]
+    weight_rows.extend(f"{asset},{0.5 if idx == 0 else 0.25}" for idx, asset in enumerate(assets))
+    weights_path.write_text("\n".join(weight_rows), encoding="utf-8")
+
+    out_dir = tmp_path / "baseline_cap"
+    main(
+        [
+            "--csv",
+            str(returns_path),
+            "--lookback",
+            "10",
+            "--step",
+            "4",
+            "--baseline",
+            "cap",
+            "--cap-weights",
+            str(weights_path),
+            "--skip-plot",
+            "--out",
+            str(out_dir),
+        ]
+    )
+
+    metrics_path = out_dir / "metrics.csv"
+    baseline_equity = out_dir / "equity_baseline_cap.csv"
+
+    assert metrics_path.exists()
+    assert baseline_equity.exists()
+
+    metrics_text = metrics_path.read_text(encoding="utf-8")
+    assert "alpha_vs_baseline" in metrics_text
+    assert "baseline_info_ratio" in metrics_text


### PR DESCRIPTION
## Summary
- add CLI options to compute equal- or cap-weight baselines and load cap weight CSVs
- emit baseline equity files, metrics, and plot overlays alongside existing outputs
- add regression tests covering equal and cap baseline configurations via the CLI

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d90046607c8333926285bd51480567