### PR TITLE
Add CLI performance toggles and float32 mode

### DIFF
--- a/neuro-ant-optimizer/README.md
+++ b/neuro-ant-optimizer/README.md
@@ -101,6 +101,18 @@ data.
 
 ---
 
+### Recipes
+
+| Config | Command | Highlights | Expected artifacts |
+| --- | --- | --- | --- |
+| `minimal.yaml` | `neuro-ant-backtest --config examples/configs/minimal.yaml` | Baseline sample-covariance run without factors. | `runs/minimal/metrics.csv`<br>`runs/minimal/rebalance_report.csv`<br>`runs/minimal/weights.csv` |
+| `daily_oas.yaml` | `neuro-ant-backtest --config examples/configs/daily_oas.yaml` | Daily OAS covariance with strict factor alignment, amortized costs, and slippage. | `runs/daily_oas/metrics.csv`<br>`runs/daily_oas/rebalance_report.csv`<br>`runs/daily_oas/factor_diagnostics.json`<br>`runs/daily_oas/weights.csv` |
+| `weekly_subset.yaml` | `neuro-ant-backtest --config examples/configs/weekly_subset.yaml` | Weekly run that allows factor gaps (`subset` alignment) and logs posthoc costs. | `runs/weekly_subset/metrics.csv`<br>`runs/weekly_subset/rebalance_report.csv`<br>`runs/weekly_subset/equity_net_of_tc.csv`<br>`runs/weekly_subset/factor_diagnostics.json` |
+
+Each command resolves paths relative to the repository root. Change `--out` inside the YAML files if you prefer a different artifact directory.
+
+---
+
 ### Verifying CLI outputs
 
 The CLI writes every artifact into the directory passed via `--out`. After a run, list
@@ -130,6 +142,18 @@ If the dataset is shorter than the configured `--lookback`, the CLI still emits
 inspect `run_config.json` for `"warnings": ["no_rebalances"]` to confirm the guardrail
 was triggered. Provide a longer history or decrease the lookback to produce rebalance
 windows.
+
+---
+
+### Troubleshooting
+
+| Symptom | How to resolve |
+| --- | --- |
+| No rebalances (empty `rebalance_report.csv`, `"warnings": ["no_rebalances"]`) | Ensure the dataset has at least `lookback + step` rows or lower the lookback/step so the rolling window fits the history. |
+| Factor gaps reported in `factor_diagnostics.json` | Switch to `factor_align: subset` to allow gaps, adjust `factors_required`, or extend the factor panel so every rebalance date has coverage. |
+| PSD repair warnings or singular covariance | Enable shrinkage via `use_shrinkage: true`, choose a regularized model such as `cov_model: lw`/`oas`, or shorten the lookback relative to the universe size. |
+| NaNs detected in returns or factors | Sanitize inputs before running (drop missing rows, forward-fill, or clip infinities) so the optimizer can project feasible weights. |
+| Reported Sharpe differs from expectations with a risk-free rate | Set `--rf-bps` (CLI) or `risk_free_rate` (API) to your benchmark value and verify `--trading-days` matches the data frequency used to annualize results. |
 
 ---
 

--- a/neuro-ant-optimizer/tests/test_backtest_json_logging.py
+++ b/neuro-ant-optimizer/tests/test_backtest_json_logging.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from neuro_ant_optimizer.backtest.backtest import main as backtest_main
+
+
+def test_cli_json_logging_schema(tmp_path: Path) -> None:
+    out_dir = tmp_path / "cli_out"
+    log_path = tmp_path / "rebalance.jsonl"
+
+    args = [
+        "--csv",
+        "backtest/sample_returns.csv",
+        "--lookback",
+        "4",
+        "--step",
+        "2",
+        "--cov-model",
+        "sample",
+        "--objective",
+        "sharpe",
+        "--seed",
+        "123",
+        "--out",
+        str(out_dir),
+        "--skip-plot",
+        "--log-json",
+        str(log_path),
+        "--progress",
+    ]
+
+    backtest_main(args)
+
+    lines = log_path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(lines) >= 2
+
+    expected_top_keys = {
+        "date",
+        "seed",
+        "objective",
+        "cov_model",
+        "costs",
+        "turnover",
+        "feasible",
+        "breaches",
+        "block",
+        "timings",
+    }
+    expected_cost_keys = {"tx", "slippage"}
+    expected_breach_keys = {"active", "group", "factor", "sector"}
+    expected_block_keys = {"sharpe", "sortino", "ir", "te"}
+    expected_timing_keys = {"cov_ms", "opt_ms"}
+
+    for raw_line in lines[:2]:
+        payload = json.loads(raw_line)
+        assert set(payload) == expected_top_keys
+        assert isinstance(payload["date"], str)
+        assert payload["seed"] == 123
+        assert payload["objective"] == "sharpe"
+        assert payload["cov_model"] == "sample"
+        assert isinstance(payload["turnover"], float)
+        assert isinstance(payload["feasible"], bool)
+
+        costs = payload["costs"]
+        assert set(costs) == expected_cost_keys
+        for key in expected_cost_keys:
+            assert isinstance(costs[key], float)
+
+        breaches = payload["breaches"]
+        assert set(breaches) == expected_breach_keys
+        for key in expected_breach_keys:
+            assert isinstance(breaches[key], int)
+
+        block = payload["block"]
+        assert set(block) == expected_block_keys
+        assert isinstance(block["sharpe"], float)
+        assert isinstance(block["sortino"], float)
+        assert (block["ir"] is None) or isinstance(block["ir"], float)
+        assert (block["te"] is None) or isinstance(block["te"], float)
+
+        timings = payload["timings"]
+        assert set(timings) == expected_timing_keys
+        for key in expected_timing_keys:
+            assert isinstance(timings[key], float)
+            assert timings[key] >= 0.0

--- a/neuro-ant-optimizer/tests/test_backtest_perf_toggles.py
+++ b/neuro-ant-optimizer/tests/test_backtest_perf_toggles.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+import numpy as np
+
+from neuro_ant_optimizer.backtest.backtest import backtest, _read_csv
+
+
+def _load_sample_returns():
+    csv_path = Path("backtest/sample_returns.csv")
+    return _read_csv(csv_path)
+
+
+def test_float32_equity_close() -> None:
+    df = _load_sample_returns()
+
+    result64 = backtest(df, lookback=4, step=2, seed=123, dtype=np.float64)
+    result32 = backtest(df, lookback=4, step=2, seed=123, dtype=np.float32)
+
+    assert result64["dtype"] == "float64"
+    assert result32["dtype"] == "float32"
+    assert np.allclose(result64["equity"], result32["equity"], atol=1e-6)
+
+
+def test_covariance_cache_evictions() -> None:
+    df = _load_sample_returns()
+
+    generous = backtest(df, lookback=4, step=2, seed=123, cov_cache_size=16)
+    tiny = backtest(df, lookback=4, step=2, seed=123, cov_cache_size=1)
+
+    generous_stats = generous["cov_cache_stats"]
+    tiny_stats = tiny["cov_cache_stats"]
+
+    assert generous_stats["size"] == 16
+    assert tiny_stats["size"] == 1
+    assert generous_stats["misses"] == tiny_stats["misses"]
+    assert generous_stats["evictions"] == 0
+    assert tiny_stats["evictions"] > 0


### PR DESCRIPTION
## Summary
- add CLI options for float32 precision, covariance cache sizing, and max worker hints
- propagate dtype control through the backtest pipeline and expose covariance cache statistics
- cover the new toggles with regression tests for float32 equity parity and cache eviction tracking

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d92325cab88333bb43f927cce60e03