### PR TITLE
Add pip caching and pre-commit enforcement to CI

### DIFF
--- a/neuro-ant-optimizer/.github/workflows/ci.yml
+++ b/neuro-ant-optimizer/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: ci
 on:
-  push: { branches: [ "**" ] }
+  push:
+    branches: [ "**" ]
+    tags: [ "v*" ]
   pull_request:
 jobs:
   determinism:
@@ -11,6 +13,13 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
       - name: Install deps (determinism)
         run: |
           python -m pip install --upgrade pip
@@ -29,13 +38,24 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('pyproject.toml', '.pre-commit-config.yaml') }}-${{ matrix.python-version }}
+          restore-keys: |
+            ${{ runner.os }}-pip-${{ matrix.python-version }}-
+            ${{ runner.os }}-pip-
       - name: Install deps (minimal CPU)
         run: |
           python -m pip install --upgrade pip
           pip install numpy scipy torch pytest pytest-cov build
-          pip install ruff mypy
+          pip install ruff mypy pre-commit
           # optional extras for CLI smoke
           pip install pandas matplotlib
+      - name: Pre-commit
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
+        run: pre-commit run --all-files --show-diff-on-failure
       - name: Run tests
         run: |
           if [ "${{ matrix.os }}" = "ubuntu-latest" ] && [ "${{ matrix.python-version }}" = "3.11" ]; then
@@ -49,11 +69,6 @@ jobs:
         with:
           name: coverage-html-${{ matrix.python-version }}-${{ matrix.os }}
           path: htmlcov
-      - name: Ruff (lint)
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
-        run: |
-          ruff --version
-          ruff check neuro-ant-optimizer/src neuro-ant-optimizer/tests
       - name: mypy (types)
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
         env:
@@ -72,4 +87,32 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: wheel-${{ matrix.os }}-py${{ matrix.python-version }}
+          path: dist/*.whl
+  release:
+    name: release build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [test]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-release-${{ hashFiles('pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: Install build backend
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+      - name: Build wheel
+        run: python -m build --wheel
+      - name: Upload release wheel
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheel-${{ github.ref_name }}
           path: dist/*.whl

--- a/neuro-ant-optimizer/.pre-commit-config.yaml
+++ b/neuro-ant-optimizer/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.5.6
+    hooks:
+      - id: ruff
+        args: [--force-exclude]
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+  - repo: https://github.com/executablebooks/mdformat
+    rev: 0.7.17
+    hooks:
+      - id: mdformat
+        additional_dependencies:
+          - mdformat-gfm

--- a/neuro-ant-optimizer/pyproject.toml
+++ b/neuro-ant-optimizer/pyproject.toml
@@ -24,7 +24,13 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest>=7.4", "pytest-cov>=4.1", "ruff>=0.5.0", "mypy>=1.10"]
+dev = [
+  "pytest>=7.4",
+  "pytest-cov>=4.1",
+  "ruff>=0.5.0",
+  "mypy>=1.10",
+  "pre-commit>=3.7",
+]
 backtest = ["pandas>=2.0", "matplotlib>=3.7"]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- cache pip installations across all CI jobs and add a tagged release build that publishes the wheel artifact
- configure and run pre-commit with ruff, isort, and mdformat while adding pre-commit to the development extras

## Testing
- not run (network restrictions prevented installing tooling locally)


------
https://chatgpt.com/codex/tasks/task_e_68d9311f144c8333bdc007f9ac665152