### PR TITLE
Add sweep CLI, plugin registries, and diagnostics outputs

### DIFF
--- a/neuro-ant-optimizer/src/neuro_ant_optimizer/__init__.py
+++ b/neuro-ant-optimizer/src/neuro_ant_optimizer/__init__.py
@@ -16,7 +16,7 @@ from .optimizer import (
     OptimizationResult,
     OptimizerConfig,
 )
-from .backtest.backtest import ewma_cov
+from .backtest.backtest import ewma_cov, register_cov_model, register_objective
 
 __all__ = [
     "NeuroAntPortfolioOptimizer",
@@ -27,4 +27,6 @@ __all__ = [
     "BenchmarkStats",
     "__version__",
     "ewma_cov",
+    "register_objective",
+    "register_cov_model",
 ]

--- a/neuro-ant-optimizer/tests/test_backtest_custom_plugins.py
+++ b/neuro-ant-optimizer/tests/test_backtest_custom_plugins.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from importlib import import_module
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+bt = import_module("neuro_ant_optimizer.backtest.backtest")
+
+
+class _StubOptimizer:
+    def __init__(self):
+        self.cfg = SimpleNamespace(use_shrinkage=False, shrinkage_delta=0.0)
+        self.seen_objectives: list[object] = []
+
+    def optimize(self, mu, cov, constraints, objective=None, **_):  # type: ignore[override]
+        if objective is not None:
+            self.seen_objectives.append(objective)
+        n = mu.shape[0]
+        return SimpleNamespace(
+            weights=np.full(n, 1.0 / n),
+            feasible=True,
+            projection_iterations=0,
+        )
+
+
+def test_register_objective(monkeypatch) -> None:
+    returns = np.array(
+        [
+            [0.01, 0.02, -0.01],
+            [0.0, 0.01, 0.005],
+            [0.02, -0.01, 0.0],
+            [0.015, 0.01, -0.005],
+        ]
+    )
+    stub = _StubOptimizer()
+    monkeypatch.setattr(bt, "_build_optimizer", lambda *args, **kwargs: stub)
+
+    def my_return(weights, mu, cov, constraints, benchmark, workspace=None):
+        return float(weights @ mu)
+
+    bt.register_objective("my_return", my_return)
+    bt.backtest(returns, lookback=2, step=2, objective="my_return")
+    assert stub.seen_objectives and callable(stub.seen_objectives[0])
+
+
+def test_register_cov_model(monkeypatch) -> None:
+    returns = np.array(
+        [
+            [0.01, 0.02],
+            [0.0, 0.01],
+            [0.015, -0.01],
+            [-0.01, 0.005],
+        ]
+    )
+
+    def identity_cov(data: np.ndarray, **_: object) -> np.ndarray:
+        n = data.shape[1]
+        return np.eye(n)
+
+    bt.register_cov_model("identity", identity_cov)
+    results = bt.backtest(returns, lookback=2, step=2, cov_model="identity")
+    assert "equity" in results
+
+
+def test_custom_objective_import_error(tmp_path: Path) -> None:
+    csv_path = tmp_path / "returns.csv"
+    csv_path.write_text("date,A\n2020-01-01,0.01\n2020-01-02,0.02\n")
+    out_dir = tmp_path / "out"
+    with pytest.raises(ValueError) as excinfo:
+        bt.main(
+            [
+                "--csv",
+                str(csv_path),
+                "--lookback",
+                "1",
+                "--step",
+                "1",
+                "--objective",
+                "custom:not.real:fn",
+                "--out",
+                str(out_dir),
+            ]
+        )
+    assert "Failed to import" in str(excinfo.value)
+
+
+def test_custom_cov_model_import(tmp_path: Path, monkeypatch) -> None:
+    module_path = tmp_path / "my_cov.py"
+    module_path.write_text(
+        "import numpy as np\n"
+        "def build_cov(returns, **kwargs):\n"
+        "    n = returns.shape[1]\n"
+        "    return np.eye(n)\n"
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    csv_path = tmp_path / "returns.csv"
+    csv_path.write_text(
+        "date,A,B\n"
+        "2020-01-01,0.01,0.02\n"
+        "2020-01-02,0.0,0.01\n"
+        "2020-01-03,0.02,-0.01\n"
+    )
+    out_dir = tmp_path / "out"
+    bt.main(
+        [
+            "--csv",
+            str(csv_path),
+            "--lookback",
+            "2",
+            "--step",
+            "1",
+            "--cov-model",
+            "custom:my_cov:build_cov",
+            "--out",
+            str(out_dir),
+            "--skip-plot",
+        ]
+    )
+    assert (out_dir / "metrics.csv").exists()

--- a/neuro-ant-optimizer/tests/test_backtest_drawdown_contrib.py
+++ b/neuro-ant-optimizer/tests/test_backtest_drawdown_contrib.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from importlib import import_module
+from pathlib import Path
+from types import SimpleNamespace
+
+import math
+
+import numpy as np
+
+bt = import_module("neuro_ant_optimizer.backtest.backtest")
+
+
+class _StubOptimizer:
+    def __init__(self, weights_seq: list[np.ndarray]):
+        self.weights_seq = weights_seq
+        self.calls = 0
+        self.cfg = SimpleNamespace(use_shrinkage=False, shrinkage_delta=0.0)
+        self.objectives: list[object] = []
+
+    def optimize(self, *_, objective=None, **__):  # type: ignore[override]
+        if objective is not None:
+            self.objectives.append(objective)
+        weights = self.weights_seq[self.calls]
+        self.calls += 1
+        return SimpleNamespace(
+            weights=weights,
+            feasible=True,
+            projection_iterations=0,
+        )
+
+
+def test_drawdowns_and_contributions(monkeypatch) -> None:
+    returns = np.array(
+        [
+            [0.02, 0.01],
+            [-0.01, 0.005],
+            [0.015, -0.02],
+            [0.01, 0.012],
+            [-0.03, -0.015],
+            [0.02, 0.01],
+        ]
+    )
+    weights_seq = [
+        np.array([0.7, 0.3], dtype=float),
+        np.array([0.4, 0.6], dtype=float),
+    ]
+    stub = _StubOptimizer(weights_seq)
+    monkeypatch.setattr(bt, "_build_optimizer", lambda *args, **kwargs: stub)
+
+    results = bt.backtest(returns, lookback=3, step=2, seed=1)
+
+    drawdowns = results["drawdowns"]
+    assert drawdowns, "drawdown events should be recorded"
+    expected_drawdowns = bt.compute_drawdown_events(results["equity"], results["dates"])
+    assert drawdowns == expected_drawdowns
+
+    contrib_rows = results["contributions"]
+    assert contrib_rows
+    totals: dict[object, float] = {}
+    sums: dict[object, float] = {}
+    for row in contrib_rows:
+        key = row["date"]
+        totals[key] = row["block_return"]
+        sums[key] = sums.get(key, 0.0) + float(row["contribution"])
+    for key, total in totals.items():
+        assert math.isclose(sums[key], float(total), rel_tol=1e-9, abs_tol=1e-9)
+
+
+def test_cli_emits_drawdown_and_contrib(tmp_path: Path) -> None:
+    csv_path = Path("backtest/sample_returns.csv")
+    out_dir = tmp_path / "cli"
+    bt.main(
+        [
+            "--csv",
+            str(csv_path),
+            "--lookback",
+            "5",
+            "--step",
+            "3",
+            "--out",
+            str(out_dir),
+            "--skip-plot",
+        ]
+    )
+    assert (out_dir / "drawdowns.csv").exists()
+    assert (out_dir / "contrib.csv").exists()

--- a/neuro-ant-optimizer/tests/test_backtest_sweep.py
+++ b/neuro-ant-optimizer/tests/test_backtest_sweep.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+import json
+from importlib import import_module
+
+bt = import_module("neuro_ant_optimizer.backtest.backtest")
+
+
+def _write_returns(path: Path) -> None:
+    with path.open("w", newline="") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["date", "A", "B"])
+        writer.writerow(["2020-01-01", 0.01, 0.0])
+        writer.writerow(["2020-01-02", 0.0, 0.01])
+        writer.writerow(["2020-01-03", 0.02, -0.01])
+        writer.writerow(["2020-01-04", -0.01, 0.015])
+        writer.writerow(["2020-01-05", 0.015, 0.005])
+
+
+def test_sweep_config_runs(tmp_path: Path) -> None:
+    csv_path = tmp_path / "returns.csv"
+    _write_returns(csv_path)
+    config_path = tmp_path / "sweep.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "base": {
+                    "csv": str(csv_path),
+                    "lookback": 3,
+                    "step": 2,
+                    "skip_plot": True,
+                },
+                "grid": {"seed": [1, 3]},
+            }
+        )
+    )
+
+    out_dir = tmp_path / "runs"
+    bt.main(["sweep", "--config", str(config_path), "--out", str(out_dir)])
+
+    results = sorted(out_dir.glob("run_*"))
+    assert len(results) == 2
+    summary = out_dir / "sweep_results.csv"
+    assert summary.exists()
+    rows = list(csv.DictReader(summary.open()))
+    assert len(rows) == 2
+    seeds = {row["param_seed"] for row in rows}
+    assert seeds == {"1", "3"}
+
+
+def test_sweep_grid_cli(tmp_path: Path) -> None:
+    csv_path = tmp_path / "returns.csv"
+    _write_returns(csv_path)
+    out_dir = tmp_path / "runs"
+    bt.main(
+        [
+            "sweep",
+            "--csv",
+            str(csv_path),
+            "--lookback",
+            "3",
+            "--step",
+            "2",
+            "--grid",
+            "seed=4,5",
+            "--out",
+            str(out_dir),
+            "--skip-plot",
+        ]
+    )
+    summary = out_dir / "sweep_results.csv"
+    rows = list(csv.DictReader(summary.open()))
+    assert {row["param_seed"] for row in rows} == {"4", "5"}


### PR DESCRIPTION
## Summary
- add hyperparameter sweep command with CSV summaries and parameter registries for objectives and covariance models
- emit drawdown/contribution diagnostics and support drawdown plotting
- cover new features with sweep, plugin, and diagnostics unit tests

## Testing
- pytest tests/test_backtest_drawdown_contrib.py tests/test_backtest_sweep.py tests/test_backtest_custom_plugins.py

------
https://chatgpt.com/codex/tasks/task_e_68d95ef16c748333bf28136e88c8c8e9