### PR TITLE
Add bootstrap confidence intervals and CV reporting

### DIFF
--- a/neuro-ant-optimizer/tests/test_bootstrap_cv.py
+++ b/neuro-ant-optimizer/tests/test_bootstrap_cv.py
@@ -1,0 +1,53 @@
+import csv
+import json
+from pathlib import Path
+
+from neuro_ant_optimizer.backtest.backtest import main as backtest_main
+
+
+def _run_backtest(out_dir: Path, extra_args: list[str]) -> None:
+    base_args = [
+        "--csv",
+        "backtest/sample_returns.csv",
+        "--lookback",
+        "3",
+        "--step",
+        "2",
+        "--objective",
+        "sharpe",
+        "--seed",
+        "123",
+        "--out",
+        str(out_dir),
+        "--skip-plot",
+    ]
+    backtest_main(base_args + extra_args)
+
+
+def test_bootstrap_confidence_interval_shrinks(tmp_path: Path) -> None:
+    small_dir = tmp_path / "small"
+    large_dir = tmp_path / "large"
+
+    _run_backtest(small_dir, ["--bootstrap", "10", "--block", "2"])
+    _run_backtest(large_dir, ["--bootstrap", "40", "--block", "2"])
+
+    small_ci = json.loads((small_dir / "metrics_ci.json").read_text())
+    large_ci = json.loads((large_dir / "metrics_ci.json").read_text())
+
+    small_width = small_ci["sharpe"]["upper"] - small_ci["sharpe"]["lower"]
+    large_width = large_ci["sharpe"]["upper"] - large_ci["sharpe"]["lower"]
+
+    assert large_width <= small_width + 1e-9
+
+
+def test_cv_results_written(tmp_path: Path) -> None:
+    cv_dir = tmp_path / "cv"
+    _run_backtest(cv_dir, ["--cv", "k=3"])
+
+    csv_path = cv_dir / "cv_results.csv"
+    assert csv_path.exists()
+
+    rows = list(csv.reader(csv_path.open()))
+    assert rows
+    header = rows[0]
+    assert header[:3] == ["fold", "start", "end"]


### PR DESCRIPTION
## Summary
- extend the backtest CLI/config with block bootstrap and walk-forward cross-validation options and write metrics_ci.json / cv_results.csv artifacts
- add reusable helpers for block resampling, confidence interval computation, and cross-validation evaluations in the backtest engine
- cover the new functionality with unit tests that exercise bootstrap CI narrowing and cross-validation output generation

## Testing
- pytest tests/test_bootstrap_cv.py

------
https://chatgpt.com/codex/tasks/task_e_68d97f2e30cc83339cb14edda4650d45