### PR TITLE
Add impact slippage model and trade control options

### DIFF
--- a/neuro-ant-optimizer/docs/artifacts.md
+++ b/neuro-ant-optimizer/docs/artifacts.md
@@ -30,6 +30,7 @@ One row per rebalance window with feasibility, turnover, and diagnostic metrics.
 | `gross_ret` / `net_tx_ret` / `net_slip_ret` | Block returns before costs, net of transaction costs, and net of slippage. |
 | `turnover_pre_decay` / `turnover_post_decay` | Turnover before and after applying the decay blend. `turnover` mirrors the post-decay value. |
 | `tx_cost` / `slippage_cost` | Costs incurred during the block. |
+| `nt_band_hits` / `participation_breaches` | Count of assets skipped by the no-trade band and clipped by participation caps. |
 | `sector_breaches` / `active_breaches` / `group_breaches` / `factor_bound_breaches` | Count of constraint violations detected after projection. |
 | `factor_inf_norm` | Infinity norm of factor exposures relative to the target vector. |
 | `factor_missing` | `True` if the factor panel lacked data for this window. |

--- a/neuro-ant-optimizer/docs/config.md
+++ b/neuro-ant-optimizer/docs/config.md
@@ -46,7 +46,8 @@ The CLI and YAML/JSON configs expose the same knobs. The table below lists every
 | `--factor-targets` | `None` | CSV/Parquet/YAML vector of factor targets. |
 | `--factor-align` | `strict` | Factor alignment policy (`strict` requires full coverage, `subset` allows gaps). |
 | `--factors-required` | `False` | Fail if any rebalance window lacks factor data (even in `subset` mode). |
-| `--slippage` | `None` | Slippage model spec (for example `proportional:5`). |
+| `--slippage` | `None` | Slippage model spec (e.g. `impact:k=25,alpha=1.5,spread=2bps`). |
+| `--nt-band` | `0` | No-trade band around the previous weights (accepts decimals, `%`, or `bps`). |
 | `--refine-every` | `1` | Run SLSQP refinement every *k* rebalances. |
 
 ## Configuration files

--- a/neuro-ant-optimizer/tests/test_backtest_factors_slippage.py
+++ b/neuro-ant-optimizer/tests/test_backtest_factors_slippage.py
@@ -130,7 +130,9 @@ def test_backtest_cli_with_factors_and_slippage(tmp_path: Path) -> None:
             "--factors",
             str(factor_path),
             "--slippage",
-            "proportional:10",
+            "impact:k=25,alpha=1.5",
+            "--nt-band",
+            "5bps",
             "--out",
             str(out_dir),
         ]

--- a/neuro-ant-optimizer/tests/test_backtest_json_logging.py
+++ b/neuro-ant-optimizer/tests/test_backtest_json_logging.py
@@ -45,6 +45,8 @@ def test_cli_json_logging_schema(tmp_path: Path) -> None:
         "turnover",
         "turnover_pre_decay",
         "turnover_post_decay",
+        "nt_band_hits",
+        "participation_breaches",
         "warm_applied",
         "decay",
         "feasible",
@@ -67,6 +69,8 @@ def test_cli_json_logging_schema(tmp_path: Path) -> None:
         assert isinstance(payload["turnover"], float)
         assert isinstance(payload["turnover_pre_decay"], float)
         assert isinstance(payload["turnover_post_decay"], float)
+        assert isinstance(payload["nt_band_hits"], int)
+        assert isinstance(payload["participation_breaches"], int)
         assert isinstance(payload["warm_applied"], bool)
         assert isinstance(payload["decay"], float)
         assert isinstance(payload["feasible"], bool)

--- a/neuro-ant-optimizer/tests/test_backtest_rebalance_report.py
+++ b/neuro-ant-optimizer/tests/test_backtest_rebalance_report.py
@@ -113,6 +113,8 @@ def test_rebalance_report_and_net_returns(tmp_path: Path, monkeypatch) -> None:
         assert record["gross_ret"] == pytest.approx(expected_gross)
         assert record["net_tx_ret"] == pytest.approx(expected_net_tx)
         assert record["net_slip_ret"] == pytest.approx(expected_net_tx)
+        assert record["nt_band_hits"] == 0
+        assert record["participation_breaches"] == 0
         assert record["sector_breaches"] == 0
         assert record["active_breaches"] == 0
         assert record["group_breaches"] == 0
@@ -153,10 +155,10 @@ def test_rebalance_report_and_net_returns(tmp_path: Path, monkeypatch) -> None:
     text = report_path.read_text().splitlines()
     assert text[0] == (
         "date,gross_ret,net_tx_ret,net_slip_ret,turnover,turnover_pre_decay,"
-        "turnover_post_decay,tx_cost,slippage_cost,sector_breaches,active_breaches,"
-        "group_breaches,factor_bound_breaches,factor_inf_norm,factor_missing,first_violation,"
-        "feasible,projection_iterations,block_sharpe,block_sortino,block_info_ratio,"
-        "block_tracking_error,warm_applied,decay"
+        "turnover_post_decay,tx_cost,slippage_cost,nt_band_hits,participation_breaches,"
+        "sector_breaches,active_breaches,group_breaches,factor_bound_breaches,factor_inf_norm,"
+        "factor_missing,first_violation,feasible,projection_iterations,block_sharpe,"
+        "block_sortino,block_info_ratio,block_tracking_error,warm_applied,decay"
     )
 
 

--- a/neuro-ant-optimizer/tests/test_no_trade_band.py
+++ b/neuro-ant-optimizer/tests/test_no_trade_band.py
@@ -1,0 +1,151 @@
+import numpy as np
+from importlib import import_module
+
+bt = import_module("neuro_ant_optimizer.backtest.backtest")
+
+
+class _Frame:
+    def __init__(self, arr: np.ndarray, dates: np.ndarray, cols: list[str]):
+        self._arr = arr
+        self._idx = list(dates)
+        self._cols = cols
+
+    def to_numpy(self, dtype=float):
+        return self._arr.astype(dtype)
+
+    @property
+    def index(self):  # pragma: no cover - simple accessor
+        return self._idx
+
+    @property
+    def columns(self):  # pragma: no cover - simple accessor
+        return self._cols
+
+
+class _StubOptimizer:
+    def __init__(self, weights_seq: list[np.ndarray]):
+        self.weights_seq = weights_seq
+        self.calls = 0
+        self.cfg = type("Cfg", (), {"use_shrinkage": False, "shrinkage_delta": 0.0})()
+
+    def optimize(self, *_, **__):
+        weights = self.weights_seq[self.calls]
+        self.calls += 1
+
+        class _Result:
+            def __init__(self, w: np.ndarray):
+                self.weights = w
+                self.feasible = True
+                self.projection_iterations = 0
+
+        return _Result(weights)
+
+
+def test_no_trade_band_reduces_turnover(monkeypatch):
+    n_periods = 12
+    dates = np.array(
+        [np.datetime64("2022-01-01") + np.timedelta64(i, "D") for i in range(n_periods)]
+    )
+    returns = np.array(
+        [
+            [0.01, 0.0],
+            [0.02, -0.01],
+            [0.0, 0.01],
+            [0.03, 0.01],
+            [0.02, 0.0],
+            [0.01, 0.02],
+            [0.0, -0.01],
+            [0.01, 0.03],
+            [0.0, 0.02],
+            [0.02, 0.01],
+            [0.01, -0.02],
+            [0.03, 0.0],
+        ],
+        dtype=float,
+    )
+    frame = _Frame(returns, dates, ["A", "B"])
+
+    weights_seq = [
+        np.array([0.50, 0.50], dtype=float),
+        np.array([0.52, 0.48], dtype=float),
+        np.array([0.51, 0.49], dtype=float),
+    ]
+
+    def _build_stub(*_args, **_kwargs):
+        return _StubOptimizer([w.copy() for w in weights_seq])
+
+    monkeypatch.setattr(bt, "_build_optimizer", _build_stub)
+    baseline = bt.backtest(
+        frame,
+        lookback=3,
+        step=3,
+        seed=0,
+        tx_cost_mode="none",
+        nt_band=0.0,
+    )
+
+    monkeypatch.setattr(bt, "_build_optimizer", _build_stub)
+    banded = bt.backtest(
+        frame,
+        lookback=3,
+        step=3,
+        seed=0,
+        tx_cost_mode="none",
+        nt_band=0.02,
+    )
+
+    assert banded["avg_turnover"] < baseline["avg_turnover"]
+    assert any(record["nt_band_hits"] > 0 for record in banded["rebalance_records"])
+
+
+def test_participation_cap_clips_trades(monkeypatch):
+    n_periods = 12
+    dates = np.array(
+        [np.datetime64("2022-06-01") + np.timedelta64(i, "D") for i in range(n_periods)]
+    )
+    returns = np.array(
+        [
+            [0.01, -0.01],
+            [0.015, 0.0],
+            [0.0, 0.01],
+            [0.02, 0.005],
+            [0.01, -0.015],
+            [0.0, 0.02],
+            [0.015, -0.005],
+            [0.0, 0.01],
+            [0.02, 0.0],
+            [0.01, -0.01],
+            [0.0, 0.015],
+            [0.02, 0.005],
+        ],
+        dtype=float,
+    )
+    frame = _Frame(returns, dates, ["A", "B"])
+
+    weights_seq = [
+        np.array([0.60, 0.40], dtype=float),
+        np.array([0.90, 0.10], dtype=float),
+        np.array([0.20, 0.80], dtype=float),
+    ]
+
+    def _build_stub(*_args, **_kwargs):
+        return _StubOptimizer([w.copy() for w in weights_seq])
+
+    monkeypatch.setattr(bt, "_build_optimizer", _build_stub)
+    slippage = bt.parse_slippage("impact:k=20,participation=0.1")
+    results = bt.backtest(
+        frame,
+        lookback=3,
+        step=3,
+        seed=0,
+        tx_cost_mode="none",
+        nt_band=0.0,
+        slippage=slippage,
+    )
+
+    weights = results["weights"]
+    assert weights.shape[0] == len(weights_seq)
+    np.testing.assert_allclose(weights[0], np.array([0.60, 0.40]), atol=1e-9)
+    np.testing.assert_allclose(weights[1], np.array([0.70, 0.30]), atol=1e-9)
+    np.testing.assert_allclose(weights[2], np.array([0.60, 0.40]), atol=1e-9)
+    assert any(record["participation_breaches"] > 0 for record in results["rebalance_records"])


### PR DESCRIPTION
## Summary
- add a configurable impact slippage model with nonlinear impact, spread, and participation parsing
- enforce no-trade bands and participation caps inside the backtest, surfacing the new metrics in logs and reports
- document the new CLI options and cover them with integration tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d984228720833382c24b837a9bc1f5