### PR TITLE
Add PIT-safe loader docs and example configs

### DIFF
--- a/neuro-ant-optimizer/docs/cookbook.md
+++ b/neuro-ant-optimizer/docs/cookbook.md
@@ -1,0 +1,79 @@
+# Cookbooks
+
+## From CSV to equity
+
+This playbook shows how to ingest raw returns, validate them against a business-day
+calendar, and run a tracked backtest.
+
+1. **Load returns with PIT safeguards**
+
+   ```python
+   from neuro_ant_optimizer.data import load_returns
+
+   returns = load_returns(
+       "examples/data/returns_daily.csv",
+       freq="B",
+       tz="UTC",
+       columns=["AAPL", "MSFT", "GOOGL"],
+       dropna="any",
+   )
+   ```
+
+   The loader coerces timestamps onto the requested calendar, fails on duplicate rows,
+   and raises `PITViolationError` when the last observation sits in the future.
+
+2. **Run the CLI with multiprocessing**
+
+   ```bash
+   neuro-ant-backtest --csv examples/data/returns_daily.csv \
+     --lookback 252 --step 21 --cov-model ewma --ewma-span 63 \
+     --baseline minvar --lambda-tc 1.5 --workers 4 --prefetch 4 \
+     --io-backend auto --out runs/tutorial_daily
+   ```
+
+   The command mirrors the `examples/configs/daily_ewma.yaml` template and emits a
+   deterministic equity curve along with the convex baseline overlay.
+
+3. **Inspect the outputs**
+
+   Each run produces `equity.csv`, `weights.csv` (when `--save-weights` is enabled),
+   and `run_config.json` which captures the loader settings, multiprocessing flags, and
+   random seed. Use `python -m neuro_ant_optimizer.backtest.reproduce --run-id ...` to
+   replay from the manifest.
+
+## PIT-safe ingestion
+
+The loader normalises timestamps by:
+
+- Aligning them against `freq` (`B`, `W`, `M`, etc.) and the requested timezone.
+- Rejecting duplicates after timezone conversion.
+- Refusing to read the final row when it points to a future instant in the provided
+  timezone (keeping backtests strictly point-in-time).
+
+Toggle PIT checks with the `pit` keyword or `--no-pit` CLI flag when replaying historic
+snapshots that intentionally embed future dates (rare but occasionally required for
+simulated feeds).
+
+## Fast path with Polars
+
+Install the optional extras and switch the backend:
+
+```bash
+python -m pip install "neuro-ant-optimizer[polars,arrow]"
+neuro-ant-backtest --config examples/configs/daily_polars_fast.yaml
+```
+
+When Polars is available the loader streams CSV/Parquet files directly into Arrow
+memory, avoiding Python object overhead. The parallel window executor remains
+bit-for-bit deterministic provided you set `--deterministic` (or `deterministic: true`
+in configs) and seed the RNG.
+
+For lighter environments without Polars, fall back to pandas by passing
+`--io-backend pandas` or rely on the built-in minimal CSV reader.
+
+## Weekly factors with transaction costs
+
+The `examples/configs/weekly_oas_factors.yaml` template demonstrates weekly data with
+OAS shrinkage, strict factor coverage, amortised transaction costs, and a risk-parity
+baseline with turnover penalties. Use it as a starting point for custom sector bounds
+or slippage models when scaling to production universes.

--- a/neuro-ant-optimizer/docs/index.md
+++ b/neuro-ant-optimizer/docs/index.md
@@ -73,6 +73,7 @@ Each configuration resolves paths relative to the working directory. Update the 
 - Read the [configuration reference](config.md) for every CLI option and config-file key.
 - Inspect [artifact schemas](artifacts.md) to integrate metrics, rebalance logs, and factor exposures into downstream workflows.
 - Follow the [reproducibility playbook](reproducibility.md) to lock down determinism, manifests, and replays.
+- Walk through the [cookbook recipes](cookbook.md) for PIT ingestion, multiprocessing tips, and Polars-enabled runs.
 
 ## Project layout
 

--- a/neuro-ant-optimizer/examples/configs/daily_ewma.yaml
+++ b/neuro-ant-optimizer/examples/configs/daily_ewma.yaml
@@ -1,0 +1,17 @@
+# Daily EWMA covariance with baseline overlay and PIT loader hints
+csv: data/returns_daily.csv
+benchmark_csv: data/benchmark_sp500.csv
+lookback: 252
+step: 21
+cov_model: ewma
+ewma_span: 63
+objective: sharpe
+baseline: minvar
+lambda_tc: 1.5
+io_backend: pandas
+prefetch: 2
+workers: 2
+dropna: any
+tx_cost_bps: 3
+tx_cost_mode: posthoc
+out: runs/daily_ewma

--- a/neuro-ant-optimizer/examples/configs/daily_polars_fast.yaml
+++ b/neuro-ant-optimizer/examples/configs/daily_polars_fast.yaml
@@ -1,0 +1,15 @@
+# Daily sample covariance using the Polars fast path and multiprocessing
+csv: data/returns_daily.csv
+lookback: 126
+step: 21
+cov_model: sample
+objective: sharpe
+baseline: maxret
+lambda_tc: 0.5
+io_backend: polars
+workers: 4
+prefetch: 6
+cache_cov: 6
+progress: true
+deterministic: true
+out: runs/daily_polars_fast

--- a/neuro-ant-optimizer/examples/configs/weekly_oas_factors.yaml
+++ b/neuro-ant-optimizer/examples/configs/weekly_oas_factors.yaml
@@ -1,0 +1,23 @@
+# Weekly OAS shrinkage with strict factor alignment and TC-aware baseline
+csv: data/returns_weekly.csv
+benchmark_csv: data/benchmark.csv
+factors: data/factors_weekly.csv
+lookback: 104
+step: 13
+cov_model: oas
+objective: sharpe
+baseline: riskparity
+lambda_tc: 2.0
+factor_align: strict
+factors_required: true
+factor_tolerance: 1e-5
+workers: 2
+prefetch: 4
+io_backend: auto
+data_freq: W
+data_tz: UTC
+tx_cost_bps: 2
+tx_cost_mode: amortized
+slippage: proportional:5
+progress: true
+out: runs/weekly_oas_factors

--- a/neuro-ant-optimizer/mkdocs.yml
+++ b/neuro-ant-optimizer/mkdocs.yml
@@ -4,6 +4,7 @@ nav:
   - Configuration: config.md
   - Artifacts: artifacts.md
   - Reproducibility: reproducibility.md
+  - Cookbooks: cookbook.md
 theme:
   name: readthedocs
 repo_url: https://github.com/quantresearch/neuro-ant-optimizer

--- a/neuro-ant-optimizer/pyproject.toml
+++ b/neuro-ant-optimizer/pyproject.toml
@@ -58,12 +58,18 @@ dev = [
 backtest = ["pandas>=2.0", "matplotlib>=3.7", "pydantic>=2.7"]
 dashboard = ["pandas>=2.0", "streamlit>=1.32"]
 docs = ["mkdocs>=1.5"]
+io = ["pandas>=2.0", "pyarrow>=15.0"]
+polars = ["polars>=0.20"]
+arrow = ["pyarrow>=15.0"]
 
 [project.scripts]
 neuro-ant-backtest = "neuro_ant_optimizer.backtest.backtest:main"
 
 [tool.pytest.ini_options]
 addopts = "-q"
+markers = [
+  "slow: tests that cover multiprocessing or longer running behaviour",
+]
 
 [tool.ruff]
 line-length = 100

--- a/neuro-ant-optimizer/src/neuro_ant_optimizer/data/__init__.py
+++ b/neuro-ant-optimizer/src/neuro_ant_optimizer/data/__init__.py
@@ -1,0 +1,17 @@
+"""Data ingestion utilities."""
+
+from .loader import (
+    CalendarAlignmentError,
+    LoaderConfig,
+    LoaderError,
+    PITViolationError,
+    load_returns,
+)
+
+__all__ = [
+    "CalendarAlignmentError",
+    "LoaderConfig",
+    "LoaderError",
+    "PITViolationError",
+    "load_returns",
+]

--- a/neuro-ant-optimizer/src/neuro_ant_optimizer/data/calendars.py
+++ b/neuro-ant-optimizer/src/neuro_ant_optimizer/data/calendars.py
@@ -1,0 +1,113 @@
+"""Calendar utilities used by the data loader."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC
+from typing import List, Optional, Sequence
+
+import numpy as np
+
+try:  # pragma: no cover - optional dependency
+    import pandas as pd  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - minimal runtime
+    pd = None  # type: ignore
+
+
+class CalendarError(RuntimeError):
+    """Raised when timestamps cannot be aligned to a calendar."""
+
+
+@dataclass(frozen=True)
+class CalendarSpec:
+    freq: str
+
+    def as_pandas(self) -> str:
+        freq = self.freq.upper()
+        if freq in {"D", "DAILY"}:
+            return "D"
+        if freq in {"B", "BUSINESS"}:
+            return "B"
+        if freq in {"W", "WEEKLY"}:
+            return "W"
+        if freq in {"M", "MONTHLY"}:
+            return "M"
+        raise CalendarError(f"Unsupported calendar frequency '{self.freq}'")
+
+
+def normalize_timezone(tz: Optional[str]):
+    if tz is None:
+        return UTC
+    if pd is not None:
+        try:
+            return pd.Timestamp.now(tz=tz).tzinfo  # type: ignore[attr-defined]
+        except Exception as exc:  # pragma: no cover - fallback path
+            raise CalendarError(f"Unknown timezone '{tz}'") from exc
+    import zoneinfo
+
+    try:
+        return zoneinfo.ZoneInfo(tz)
+    except Exception as exc:  # pragma: no cover - fallback path
+        raise CalendarError(f"Unknown timezone '{tz}'") from exc
+
+
+def _ensure_datetime64(values: Sequence) -> List[np.datetime64]:
+    converted: List[np.datetime64] = []
+    for item in values:
+        if isinstance(item, np.datetime64):
+            converted.append(item)
+            continue
+        if pd is not None:
+            converted.append(np.datetime64(pd.Timestamp(item)))
+        else:
+            converted.append(np.datetime64(str(item)))
+    converted.sort()
+    return converted
+
+
+def align_calendar_index(
+    index: Sequence,
+    *,
+    freq: str,
+    tz: Optional[str],
+) -> List[np.datetime64]:
+    if not index:
+        return []
+    spec = CalendarSpec(freq=freq)
+    pandas_freq = spec.as_pandas()
+    if pd is None:
+        aligned = _ensure_datetime64(index)
+        day_array = np.array(aligned, dtype="datetime64[D]")
+        if pandas_freq == "B":
+            mask = np.is_busday(day_array)
+            if not bool(np.all(mask)):
+                bad = aligned[int(np.argmax(~mask))]
+                raise CalendarError(f"Timestamp {bad} not aligned with {pandas_freq} calendar")
+        elif pandas_freq == "W":
+            diffs = np.diff(day_array)
+            if diffs.size and not np.all(diffs == np.timedelta64(7, "D")):
+                bad = aligned[int(np.argmax(diffs != np.timedelta64(7, "D")) + 1)]
+                raise CalendarError(f"Timestamp {bad} not aligned with {pandas_freq} calendar")
+        elif pandas_freq == "M":
+            months = day_array.astype("datetime64[M]")
+            diffs = np.diff(months)
+            if diffs.size and not np.all(diffs == np.timedelta64(1, "M")):
+                bad = aligned[int(np.argmax(diffs != np.timedelta64(1, "M")) + 1)]
+                raise CalendarError(f"Timestamp {bad} not aligned with {pandas_freq} calendar")
+        return aligned
+    tzinfo = normalize_timezone(tz)
+    dt_index = pd.DatetimeIndex(index)
+    if dt_index.tzinfo is None:
+        dt_index = dt_index.tz_localize(tzinfo)
+    else:
+        dt_index = dt_index.tz_convert(tzinfo)
+    dt_index = dt_index.sort_values()
+    expected = pd.date_range(dt_index[0], dt_index[-1], freq=pandas_freq, tz=tzinfo)
+    if not dt_index.isin(expected).all():
+        mismatch = dt_index[~dt_index.isin(expected)]
+        first = mismatch[0] if len(mismatch) else dt_index[0]
+        raise CalendarError(f"Timestamp {first} not aligned with {pandas_freq} calendar")
+    return [np.datetime64(val.tz_convert(UTC)) for val in dt_index]
+
+
+__all__ = ["align_calendar_index", "CalendarSpec", "CalendarError", "normalize_timezone"]

--- a/neuro-ant-optimizer/src/neuro_ant_optimizer/data/loader.py
+++ b/neuro-ant-optimizer/src/neuro_ant_optimizer/data/loader.py
@@ -1,0 +1,285 @@
+"""Market data loaders with point-in-time safeguards."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Mapping, MutableSequence, Optional, Sequence, Tuple, Union
+
+import numpy as np
+
+from .calendars import CalendarError, align_calendar_index, normalize_timezone
+
+try:  # pragma: no cover - optional dependency
+    import pandas as pd  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - minimal runtime
+    pd = None  # type: ignore
+
+try:  # pragma: no cover - optional dependency
+    import polars as pl  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - minimal runtime
+    pl = None  # type: ignore
+
+FrameLike = Union["_BasicFrame", "pd.DataFrame"]
+
+
+@dataclass
+class LoaderConfig:
+    """Runtime options for :func:`load_returns`."""
+
+    freq: str
+    tz: Optional[str]
+    pit: bool = True
+    backend: str = "auto"
+    dropna: str = "none"
+    rename: Optional[Mapping[str, str]] = None
+
+
+class LoaderError(RuntimeError):
+    """Raised when the loader encounters malformed input."""
+
+
+class PITViolationError(LoaderError):
+    """Raised when point-in-time rules are violated."""
+
+
+class CalendarAlignmentError(LoaderError):
+    """Raised when the timestamp index fails to align with the requested calendar."""
+
+
+class _BasicFrame:
+    """Minimal frame wrapper mimicking pandas APIs used by the backtester."""
+
+    def __init__(self, data: np.ndarray, index: Sequence[np.datetime64], columns: Sequence[str]):
+        self._data = np.asarray(data, dtype=float)
+        self._index = list(index)
+        self._columns = list(columns)
+
+    def to_numpy(self, dtype=float) -> np.ndarray:
+        return np.asarray(self._data, dtype=dtype)
+
+    @property
+    def index(self) -> Sequence[np.datetime64]:
+        return list(self._index)
+
+    @property
+    def columns(self) -> Sequence[str]:
+        return list(self._columns)
+
+    def __len__(self) -> int:  # pragma: no cover - trivial helper
+        return len(self._index)
+
+
+def _coerce_backend(config: LoaderConfig) -> str:
+    backend = config.backend.lower().strip()
+    if backend not in {"auto", "pandas", "polars"}:
+        raise LoaderError(f"Unsupported IO backend '{config.backend}'")
+    if backend == "polars" and pl is None:
+        raise LoaderError("Polars backend requested but polars is not installed")
+    if backend == "pandas" and pd is None:
+        raise LoaderError("Pandas backend requested but pandas is not installed")
+    if backend == "auto":
+        if pl is not None:
+            return "polars"
+        if pd is not None:
+            return "pandas"
+        return "basic"
+    return backend
+
+
+def _read_with_polars(path: Path) -> Tuple[np.ndarray, Sequence, Sequence[str]]:
+    if pl is None:  # pragma: no cover - defensive
+        raise LoaderError("Polars backend not available")
+    if path.suffix.lower() in {".parquet", ".pq"}:
+        frame = pl.read_parquet(path)
+    else:
+        frame = pl.read_csv(path, try_parse_dates=True)
+    if not frame.width:
+        return np.empty((0, 0), dtype=float), [], []
+    lower_cols = [col.lower() for col in frame.columns]
+    if "date" in lower_cols:
+        date_col = frame.columns[lower_cols.index("date")]
+    else:
+        date_col = frame.columns[0]
+    value_cols = [col for col in frame.columns if col != date_col]
+    if not value_cols:
+        return np.empty((0, 0), dtype=float), [], []
+    arr = frame.select(value_cols).to_numpy().astype(float, copy=False)
+    dates = frame.select(date_col).to_series().to_list()
+    return arr, dates, value_cols
+
+
+def _read_with_pandas(path: Path) -> Tuple[np.ndarray, Sequence, Sequence[str]]:
+    if pd is None:  # pragma: no cover - defensive
+        raise LoaderError("Pandas backend not available")
+    if path.suffix.lower() in {".parquet", ".pq"}:
+        frame = pd.read_parquet(path)
+    else:
+        frame = pd.read_csv(path, parse_dates=True)
+    if frame.empty:
+        return np.empty((0, 0), dtype=float), [], []
+    if frame.index.name is None or frame.index.name.lower() not in {"date", "timestamp"}:
+        if frame.columns.size and frame.columns[0].lower() in {"date", "timestamp"}:
+            frame = frame.set_index(frame.columns[0])
+        else:
+            frame = frame.set_index(frame.columns[0])
+    values = frame.to_numpy(dtype=float, copy=False)
+    return values, list(frame.index), [str(col) for col in frame.columns]
+
+
+def _read_basic(path: Path) -> Tuple[np.ndarray, Sequence, Sequence[str]]:
+    with path.open("r", encoding="utf-8", newline="") as fh:
+        rows = [row.strip() for row in fh]
+    if not rows:
+        return np.empty((0, 0), dtype=float), [], []
+    header = rows[0].split(",")
+    cols = [col.strip() for col in header[1:]]
+    data: MutableSequence[np.ndarray] = []
+    dates: MutableSequence[str] = []
+    for line in rows[1:]:
+        if not line:
+            continue
+        tokens = [token.strip() for token in line.split(",")]
+        if len(tokens) <= 1:
+            continue
+        dates.append(tokens[0])
+        row: MutableSequence[float] = []
+        for tok in tokens[1:]:
+            if tok == "":
+                row.append(float("nan"))
+            else:
+                row.append(float(tok))
+        data.append(np.array(row, dtype=float))
+    if not data:
+        return np.empty((0, 0), dtype=float), [], cols
+    matrix = np.vstack(data)
+    return matrix, dates, cols
+
+
+def _filter_assets(matrix: np.ndarray, columns: Sequence[str], assets: Optional[Sequence[str]]):
+    if not assets:
+        return matrix, list(columns)
+    wanted = [str(asset) for asset in assets]
+    idx_map = {str(col): i for i, col in enumerate(columns)}
+    missing = [name for name in wanted if name not in idx_map]
+    if missing:
+        raise LoaderError(f"Requested assets missing from file: {', '.join(missing)}")
+    indices = [idx_map[name] for name in wanted]
+    return matrix[:, indices], wanted
+
+
+def _rename_columns(columns: Sequence[str], rename: Optional[Mapping[str, str]]) -> Sequence[str]:
+    if not rename:
+        return [str(col) for col in columns]
+    renamed = []
+    for col in columns:
+        key = str(col)
+        renamed.append(str(rename.get(key, key)))
+    return renamed
+
+
+def _apply_dropna(matrix: np.ndarray, dropna: str) -> Tuple[np.ndarray, np.ndarray]:
+    mode = dropna.lower()
+    if mode not in {"none", "any", "all"}:
+        raise LoaderError("dropna must be 'none', 'any', or 'all'")
+    if mode == "none":
+        mask = np.ones(matrix.shape[0], dtype=bool)
+        return matrix, mask
+    if mode == "any":
+        mask = ~np.any(np.isnan(matrix), axis=1)
+    else:
+        mask = ~np.all(np.isnan(matrix), axis=1)
+    return matrix[mask], mask
+
+
+def _assert_no_duplicates(index: Sequence[np.datetime64]) -> None:
+    seen = set()
+    for value in index:
+        key = np.datetime64(value)
+        if key in seen:
+            raise LoaderError(f"Duplicate timestamp detected: {value}")
+        seen.add(key)
+
+
+def load_returns(
+    path: Union[str, Path],
+    freq: str,
+    tz: Optional[str],
+    pit: bool = True,
+    columns: Optional[Union[Sequence[str], Mapping[str, str]]] = None,
+    *,
+    dropna: str = "none",
+    rename: Optional[Mapping[str, str]] = None,
+    assets: Optional[Sequence[str]] = None,
+    backend: str = "auto",
+) -> FrameLike:
+    """Load a return panel ensuring calendar alignment and PIT safety."""
+
+    if not isinstance(path, (str, Path)):
+        raise TypeError("path must be str or Path")
+    source = Path(path)
+    if not source.exists():
+        raise FileNotFoundError(f"Returns file not found: {source}")
+
+    config = LoaderConfig(freq=freq, tz=tz, pit=pit, backend=backend, dropna=dropna)
+    backend_mode = _coerce_backend(config)
+
+    if isinstance(columns, Mapping):
+        rename = dict(columns)
+        columns_seq: Optional[Sequence[str]] = list(columns.keys())
+    else:
+        columns_seq = list(columns) if columns is not None else None
+
+    if backend_mode == "polars":
+        matrix, idx_raw, cols = _read_with_polars(source)
+    elif backend_mode == "pandas":
+        matrix, idx_raw, cols = _read_with_pandas(source)
+    else:
+        matrix, idx_raw, cols = _read_basic(source)
+
+    if columns_seq:
+        matrix, cols = _filter_assets(matrix, cols, columns_seq)
+    elif assets:
+        matrix, cols = _filter_assets(matrix, cols, assets)
+
+    cols = _rename_columns(cols, rename)
+
+    if matrix.ndim != 2:
+        raise LoaderError("Loaded returns must be a 2D matrix")
+
+    matrix = matrix.astype(float, copy=False)
+
+    dropna_matrix, mask = _apply_dropna(matrix, dropna)
+    idx_raw = [idx_raw[i] for i, flag in enumerate(mask) if flag]
+
+    try:
+        aligned_index = align_calendar_index(idx_raw, freq=freq, tz=tz)
+    except CalendarError as exc:
+        raise CalendarAlignmentError(str(exc)) from exc
+    _assert_no_duplicates(aligned_index)
+    if pit and aligned_index:
+        last_dt = aligned_index[-1]
+        tzinfo = normalize_timezone(tz)
+        now_val = datetime.now(tzinfo)
+        now_cmp = np.datetime64(now_val.astimezone(UTC))
+        if np.datetime64(last_dt) > now_cmp:
+            raise PITViolationError(
+                f"Last observation {last_dt} is in the future relative to timezone {tz or 'UTC'}"
+            )
+
+    if backend_mode == "pandas" and pd is not None:
+        index = pd.DatetimeIndex(aligned_index)
+        frame = pd.DataFrame(dropna_matrix, index=index, columns=cols)
+        return frame
+
+    return _BasicFrame(dropna_matrix, aligned_index, cols)
+
+
+__all__ = [
+    "load_returns",
+    "LoaderConfig",
+    "LoaderError",
+    "PITViolationError",
+    "CalendarAlignmentError",
+]

--- a/neuro-ant-optimizer/src/neuro_ant_optimizer/examples/configs/daily_ewma.yaml
+++ b/neuro-ant-optimizer/src/neuro_ant_optimizer/examples/configs/daily_ewma.yaml
@@ -1,0 +1,17 @@
+# Daily EWMA covariance with baseline overlay and PIT loader hints
+csv: data/returns_daily.csv
+benchmark_csv: data/benchmark_sp500.csv
+lookback: 252
+step: 21
+cov_model: ewma
+ewma_span: 63
+objective: sharpe
+baseline: minvar
+lambda_tc: 1.5
+io_backend: pandas
+prefetch: 2
+workers: 2
+dropna: any
+tx_cost_bps: 3
+tx_cost_mode: posthoc
+out: runs/daily_ewma

--- a/neuro-ant-optimizer/src/neuro_ant_optimizer/examples/configs/daily_polars_fast.yaml
+++ b/neuro-ant-optimizer/src/neuro_ant_optimizer/examples/configs/daily_polars_fast.yaml
@@ -1,0 +1,15 @@
+# Daily sample covariance using the Polars fast path and multiprocessing
+csv: data/returns_daily.csv
+lookback: 126
+step: 21
+cov_model: sample
+objective: sharpe
+baseline: maxret
+lambda_tc: 0.5
+io_backend: polars
+workers: 4
+prefetch: 6
+cache_cov: 6
+progress: true
+deterministic: true
+out: runs/daily_polars_fast

--- a/neuro-ant-optimizer/src/neuro_ant_optimizer/examples/configs/weekly_oas_factors.yaml
+++ b/neuro-ant-optimizer/src/neuro_ant_optimizer/examples/configs/weekly_oas_factors.yaml
@@ -1,0 +1,23 @@
+# Weekly OAS shrinkage with strict factor alignment and TC-aware baseline
+csv: data/returns_weekly.csv
+benchmark_csv: data/benchmark.csv
+factors: data/factors_weekly.csv
+lookback: 104
+step: 13
+cov_model: oas
+objective: sharpe
+baseline: riskparity
+lambda_tc: 2.0
+factor_align: strict
+factors_required: true
+factor_tolerance: 1e-5
+workers: 2
+prefetch: 4
+io_backend: auto
+data_freq: W
+data_tz: UTC
+tx_cost_bps: 2
+tx_cost_mode: amortized
+slippage: proportional:5
+progress: true
+out: runs/weekly_oas_factors

--- a/neuro-ant-optimizer/src/neuro_ant_optimizer/portfolio/baselines.py
+++ b/neuro-ant-optimizer/src/neuro_ant_optimizer/portfolio/baselines.py
@@ -1,0 +1,149 @@
+"""Convex baseline portfolio constructors with transaction-cost penalties."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, Optional, Sequence
+
+import numpy as np
+from scipy.optimize import Bounds, LinearConstraint, minimize
+
+BaselineMode = Literal["minvar", "maxret", "riskparity"]
+
+
+@dataclass
+class BaselineResult:
+    label: str
+    weights: np.ndarray
+    returns: np.ndarray
+    turnover: float
+
+
+def _project_simplex(w: np.ndarray) -> np.ndarray:
+    w = np.asarray(w, dtype=float)
+    if w.ndim != 1:
+        raise ValueError("Weights must be a one-dimensional vector")
+    if w.size == 0:
+        return w
+    sorted_w = np.sort(w)[::-1]
+    cssv = np.cumsum(sorted_w) - 1
+    ind = np.arange(1, w.size + 1)
+    cond = sorted_w - cssv / ind > 0
+    if not np.any(cond):
+        theta = cssv[-1] / w.size
+    else:
+        rho = ind[cond][-1]
+        theta = cssv[cond][-1] / rho
+    projected = np.maximum(w - theta, 0.0)
+    total = projected.sum()
+    if total <= 0:
+        return np.full_like(projected, 1.0 / projected.size)
+    return projected / total
+
+
+def _risk_parity_objective(w: np.ndarray, cov: np.ndarray) -> float:
+    cov_w = cov @ w
+    port_var = float(np.dot(w, cov_w))
+    if port_var <= 0:
+        return 0.0
+    target = port_var / w.size
+    rc = w * cov_w
+    return float(np.sum((rc - target) ** 2))
+
+
+def _make_objective(
+    mode: BaselineMode,
+    mu: np.ndarray,
+    cov: np.ndarray,
+    lambda_tc: float,
+    prev: np.ndarray,
+) -> callable:
+    if lambda_tc < 0:
+        raise ValueError("lambda_tc must be non-negative")
+
+    def penalty(w: np.ndarray) -> float:
+        return lambda_tc * float(np.sum(np.abs(w - prev)))
+
+    if mode == "minvar":
+        def objective(w: np.ndarray) -> float:
+            return float(w @ cov @ w) + penalty(w)
+
+    elif mode == "maxret":
+        def objective(w: np.ndarray) -> float:
+            return float(-mu @ w) + penalty(w)
+
+    elif mode == "riskparity":
+        def objective(w: np.ndarray) -> float:
+            return _risk_parity_objective(w, cov) + penalty(w)
+
+    else:  # pragma: no cover - defensive
+        raise ValueError(f"Unsupported baseline mode '{mode}'")
+
+    return objective
+
+
+def _solve_baseline(
+    mode: BaselineMode,
+    returns: np.ndarray,
+    *,
+    lambda_tc: float,
+    prev_weights: Optional[Sequence[float]] = None,
+    cov: Optional[np.ndarray] = None,
+) -> np.ndarray:
+    matrix = np.asarray(returns, dtype=float)
+    if matrix.ndim != 2:
+        raise ValueError("Returns array must be two dimensional")
+    if matrix.shape[1] == 0:
+        raise ValueError("Cannot compute baseline with zero assets")
+    mu = matrix.mean(axis=0)
+    cov_matrix = np.asarray(cov, dtype=float) if cov is not None else np.cov(matrix, rowvar=False)
+    if cov_matrix.shape != (matrix.shape[1], matrix.shape[1]):
+        raise ValueError("Covariance matrix shape mismatch")
+    prev = np.asarray(prev_weights, dtype=float) if prev_weights is not None else None
+    if prev is None or prev.size != matrix.shape[1]:
+        prev = np.full(matrix.shape[1], 1.0 / matrix.shape[1], dtype=float)
+    prev = prev.astype(float)
+    prev = prev / max(prev.sum(), 1e-12)
+
+    objective = _make_objective(mode, mu, cov_matrix, float(lambda_tc), prev)
+
+    bounds = Bounds(0.0, 1.0)
+    linear = LinearConstraint(np.ones((1, matrix.shape[1])), lb=1.0, ub=1.0)
+    initial = _project_simplex(prev)
+
+    result = minimize(
+        objective,
+        initial,
+        method="SLSQP",
+        bounds=bounds,
+        constraints=[linear],
+        options={"maxiter": 500, "ftol": 1e-9, "disp": False},
+    )
+    if not result.success:
+        candidate = _project_simplex(result.x if result.x is not None else initial)
+    else:
+        candidate = _project_simplex(result.x)
+    return candidate
+
+
+def compute_baseline(
+    mode: BaselineMode,
+    returns: np.ndarray,
+    *,
+    lambda_tc: float = 0.0,
+    prev_weights: Optional[Sequence[float]] = None,
+    cov: Optional[np.ndarray] = None,
+) -> BaselineResult:
+    mode_norm = str(mode).lower()
+    if mode_norm not in {"minvar", "maxret", "riskparity"}:
+        raise ValueError("mode must be one of minvar, maxret, riskparity")
+    weights = _solve_baseline(mode_norm, returns, lambda_tc=float(lambda_tc), prev_weights=prev_weights, cov=cov)
+    returns = np.asarray(returns, dtype=float)
+    series = returns @ weights
+    prev = np.asarray(prev_weights, dtype=float) if prev_weights is not None else np.full(weights.size, 1.0 / weights.size)
+    prev = _project_simplex(prev)
+    turnover = float(np.sum(np.abs(weights - prev)))
+    return BaselineResult(label=mode_norm, weights=weights, returns=series, turnover=turnover)
+
+
+__all__ = ["BaselineResult", "compute_baseline"]

--- a/neuro-ant-optimizer/tests/test_baselines_tc.py
+++ b/neuro-ant-optimizer/tests/test_baselines_tc.py
@@ -1,0 +1,34 @@
+import numpy as np
+import pytest
+
+from neuro_ant_optimizer.portfolio.baselines import compute_baseline
+
+
+@pytest.mark.parametrize("mode", ["minvar", "maxret", "riskparity"])
+def test_baseline_turnover_penalty_monotone(mode: str) -> None:
+    rng = np.random.default_rng(7)
+    returns = rng.normal(0.001, 0.01, size=(48, 4))
+    prev = np.full(4, 0.25)
+
+    baseline_low = compute_baseline(mode, returns, lambda_tc=0.0, prev_weights=prev)
+    baseline_high = compute_baseline(mode, returns, lambda_tc=10.0, prev_weights=prev)
+
+    assert baseline_low.weights.shape == baseline_high.weights.shape == (4,)
+    assert baseline_low.returns.shape[0] == returns.shape[0]
+    assert baseline_high.returns.shape[0] == returns.shape[0]
+    assert baseline_high.turnover <= baseline_low.turnover + 1e-6
+    assert np.isfinite(baseline_high.turnover)
+
+
+def test_maxret_prefers_return_direction() -> None:
+    returns = np.array(
+        [
+            [0.02, 0.01, -0.01],
+            [0.03, 0.005, -0.02],
+            [0.015, 0.004, -0.015],
+        ]
+    )
+    result = compute_baseline("maxret", returns, lambda_tc=0.0)
+    # First asset should receive the highest weight when no penalty is applied
+    assert result.weights[0] == pytest.approx(max(result.weights))
+    assert np.isclose(result.weights.sum(), 1.0)

--- a/neuro-ant-optimizer/tests/test_loader_pit.py
+++ b/neuro-ant-optimizer/tests/test_loader_pit.py
@@ -1,0 +1,76 @@
+import csv
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from neuro_ant_optimizer.data import (
+    CalendarAlignmentError,
+    LoaderError,
+    PITViolationError,
+    load_returns,
+)
+
+
+def _write_csv(path: Path, rows: list[list[str]]) -> None:
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.writer(handle)
+        writer.writerows(rows)
+
+
+def test_loader_rejects_future_dates(tmp_path: Path) -> None:
+    tomorrow = datetime.now(tz=UTC) + timedelta(days=2)
+    rows = [
+        ["date", "A", "B"],
+        [datetime.now(tz=UTC).strftime("%Y-%m-%d"), "0.01", "0.02"],
+        [tomorrow.strftime("%Y-%m-%d"), "0.03", "0.01"],
+    ]
+    csv_path = tmp_path / "future.csv"
+    _write_csv(csv_path, rows)
+
+    with pytest.raises(PITViolationError):
+        load_returns(csv_path, freq="B", tz="UTC")
+
+
+def test_loader_duplicate_dates(tmp_path: Path) -> None:
+    date_str = datetime.now(tz=UTC).strftime("%Y-%m-%d")
+    rows = [
+        ["date", "A"],
+        [date_str, "0.01"],
+        [date_str, "0.02"],
+    ]
+    csv_path = tmp_path / "dup.csv"
+    _write_csv(csv_path, rows)
+
+    with pytest.raises(LoaderError):
+        load_returns(csv_path, freq="B", tz="UTC")
+
+
+def test_loader_calendar_alignment(tmp_path: Path) -> None:
+    # Sunday should violate a business-day calendar
+    rows = [
+        ["date", "A"],
+        ["2024-03-01", "0.01"],  # Friday
+        ["2024-03-02", "0.02"],  # Saturday
+    ]
+    csv_path = tmp_path / "calendar.csv"
+    _write_csv(csv_path, rows)
+
+    with pytest.raises(CalendarAlignmentError):
+        load_returns(csv_path, freq="B", tz="UTC")
+
+
+def test_loader_dropna_policy(tmp_path: Path) -> None:
+    rows = [
+        ["date", "A", "B"],
+        ["2024-03-01", "0.01", ""],
+        ["2024-03-04", "0.02", "0.03"],
+    ]
+    csv_path = tmp_path / "dropna.csv"
+    _write_csv(csv_path, rows)
+
+    frame = load_returns(csv_path, freq="B", tz="UTC", dropna="any")
+    data = frame.to_numpy(dtype=float)
+    assert data.shape == (1, 2)
+    np.testing.assert_allclose(data[0], [0.02, 0.03])

--- a/neuro-ant-optimizer/tests/test_perf_parallel.py
+++ b/neuro-ant-optimizer/tests/test_perf_parallel.py
@@ -1,0 +1,148 @@
+import time
+from typing import Any, Dict
+
+import numpy as np
+import pytest
+
+try:
+    import pandas as pd  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover
+    pd = None  # type: ignore
+
+from neuro_ant_optimizer.backtest.backtest import (
+    FactorPanel,
+    SlippageConfig,
+    backtest,
+)
+
+
+pytestmark = pytest.mark.slow
+
+
+def _run_backtest(workers: int | None) -> Dict[str, Any]:
+    if pd is None:
+        pytest.skip("pandas is required for this test")
+    rng = np.random.default_rng(3)
+    returns = rng.normal(0.001, 0.01, size=(36, 3))
+    index = pd.date_range("2024-01-01", periods=36, freq="B")
+    frame = pd.DataFrame(returns, index=index, columns=["A", "B", "C"])
+
+    return backtest(
+        frame,
+        lookback=12,
+        step=6,
+        objective="sharpe",
+        seed=11,
+        tx_cost_bps=0.0,
+        tx_cost_mode="none",
+        metric_alpha=0.05,
+        cov_model="sample",
+        benchmark=None,
+        dtype=np.float64,
+        cov_cache_size=2,
+        workers=workers,
+        prefetch=2,
+        deterministic=True,
+    )
+
+
+def test_parallel_results_match_single_process() -> None:
+    single_start = time.perf_counter()
+    single = _run_backtest(workers=None)
+    single_elapsed = time.perf_counter() - single_start
+
+    multi_start = time.perf_counter()
+    multi = _run_backtest(workers=2)
+    multi_elapsed = time.perf_counter() - multi_start
+
+    for key in ("returns", "weights", "rebalance_dates"):
+        single_val = single[key]
+        multi_val = multi[key]
+        if isinstance(single_val, np.ndarray):
+            np.testing.assert_allclose(single_val, multi_val)
+        else:
+            assert single_val == multi_val
+
+    assert multi_elapsed < 5.0
+    assert single_elapsed < 5.0
+
+
+def test_parallel_with_factors_and_slippage() -> None:
+    if pd is None:
+        pytest.skip("pandas is required for this test")
+
+    rng = np.random.default_rng(5)
+    returns = rng.normal(0.0008, 0.012, size=(40, 3))
+    index = pd.date_range("2024-02-01", periods=40, freq="B")
+    frame = pd.DataFrame(returns, index=index, columns=["A", "B", "C"])
+
+    factors = rng.normal(0.0, 1.0, size=(40, 3, 2))
+    panel = FactorPanel(
+        dates=list(index),
+        assets=["A", "B", "C"],
+        loadings=factors,
+        factor_names=["value", "size"],
+    )
+
+    benchmark = pd.DataFrame(
+        rng.normal(0.0005, 0.009, size=(40, 1)), index=index, columns=["SPX"]
+    )
+    slippage = SlippageConfig(model="proportional", param=5.0)
+
+    single = backtest(
+        frame,
+        lookback=15,
+        step=5,
+        objective="sharpe",
+        seed=17,
+        tx_cost_bps=2.0,
+        tx_cost_mode="amortized",
+        metric_alpha=0.1,
+        cov_model="oas",
+        factors=panel,
+        factor_align="strict",
+        factors_required=True,
+        factor_tolerance=1e-6,
+        slippage=slippage,
+        nt_band=0.01,
+        benchmark=benchmark,
+        dtype=np.float64,
+        cov_cache_size=3,
+        workers=None,
+        prefetch=2,
+        deterministic=True,
+        compute_factor_attr=True,
+    )
+
+    multi = backtest(
+        frame,
+        lookback=15,
+        step=5,
+        objective="sharpe",
+        seed=17,
+        tx_cost_bps=2.0,
+        tx_cost_mode="amortized",
+        metric_alpha=0.1,
+        cov_model="oas",
+        factors=panel,
+        factor_align="strict",
+        factors_required=True,
+        factor_tolerance=1e-6,
+        slippage=slippage,
+        nt_band=0.01,
+        benchmark=benchmark,
+        dtype=np.float64,
+        cov_cache_size=3,
+        workers=2,
+        prefetch=3,
+        deterministic=True,
+        compute_factor_attr=True,
+    )
+
+    for key in ("returns", "weights", "rebalance_dates", "factor_attr"):
+        single_val = single[key]
+        multi_val = multi[key]
+        if isinstance(single_val, np.ndarray):
+            np.testing.assert_allclose(single_val, multi_val)
+        else:
+            assert single_val == multi_val

--- a/neuro-ant-optimizer/tests/test_polars_fastpath.py
+++ b/neuro-ant-optimizer/tests/test_polars_fastpath.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from neuro_ant_optimizer.data import load_returns
+
+pl = pytest.importorskip("polars")
+
+
+def test_polars_backend_reads_parquet(tmp_path: Path) -> None:
+    df = pl.DataFrame(
+        {
+            "date": ["2024-01-02", "2024-01-03", "2024-01-04"],
+            "A": [0.01, 0.02, -0.01],
+            "B": [0.005, 0.006, 0.007],
+        }
+    )
+    parquet_path = tmp_path / "returns.parquet"
+    df.write_parquet(parquet_path)
+
+    frame = load_returns(parquet_path, freq="B", tz="UTC", backend="polars")
+    data = frame.to_numpy(dtype=float)
+    assert data.shape == (3, 2)
+    np.testing.assert_allclose(data[0], [0.01, 0.005])


### PR DESCRIPTION
## Summary
- add a point-in-time-safe data loader with calendar safeguards, convex baselines, and multiprocessing hooks in the backtest
- document the ingestion workflow with new cookbook content and expanded configuration tables, plus ship daily/weekly example configs
- extend the test suite with loader PIT checks, baseline turnover coverage, Polars fast-path validation, and deterministic parallel tests

## Testing
- pytest tests/test_loader_pit.py tests/test_baselines_tc.py tests/test_polars_fastpath.py
- pytest tests/test_perf_parallel.py

------
https://chatgpt.com/codex/tasks/task_e_68da5397e17c833390391a7791f351d4