### PR TITLE
Add intraday streaming engine, simulated broker, and scenario runner

### DIFF
--- a/neuro-ant-optimizer/pyproject.toml
+++ b/neuro-ant-optimizer/pyproject.toml
@@ -64,6 +64,9 @@ arrow = ["pyarrow>=15.0"]
 
 [project.scripts]
 neuro-ant-backtest = "neuro_ant_optimizer.backtest.backtest:main"
+neuro-ant-intraday = "neuro_ant_optimizer.intraday.cli:main"
+neuro-ant-sim = "neuro_ant_optimizer.live.cli:main"
+neuro-ant-scenario = "neuro_ant_optimizer.scenario.cli:main"
 
 [tool.pytest.ini_options]
 addopts = "-q"

--- a/neuro-ant-optimizer/src/neuro_ant_optimizer/intraday/__init__.py
+++ b/neuro-ant-optimizer/src/neuro_ant_optimizer/intraday/__init__.py
@@ -1,0 +1,5 @@
+"""Intraday execution utilities."""
+
+from .engine import FeedHandler, IntradayEngine
+
+__all__ = ["FeedHandler", "IntradayEngine"]

--- a/neuro-ant-optimizer/src/neuro_ant_optimizer/intraday/cli.py
+++ b/neuro-ant-optimizer/src/neuro_ant_optimizer/intraday/cli.py
@@ -1,0 +1,31 @@
+"""Console entry point for the intraday engine."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from ..state.positions import PositionsStore
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Display the current warm start weights for the intraday engine."""
+
+    parser = argparse.ArgumentParser(description="Neuro Ant intraday engine")
+    parser.add_argument("--state", type=Path, help="Path to the warm start state store", default=None)
+    args = parser.parse_args(argv)
+
+    store: PositionsStore | None = None
+    if args.state is not None:
+        store = PositionsStore(args.state)
+
+    weights: dict[str, Any] = {}
+    if store is not None:
+        weights = store.load()
+    print(json.dumps({"warm_start_weights": weights}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/neuro-ant-optimizer/src/neuro_ant_optimizer/intraday/engine.py
+++ b/neuro-ant-optimizer/src/neuro_ant_optimizer/intraday/engine.py
@@ -1,0 +1,77 @@
+"""Streaming intraday optimisation engine."""
+from __future__ import annotations
+
+import time
+from collections.abc import Callable, Iterable, Iterator, Mapping
+from dataclasses import dataclass
+from typing import Any, Dict, MutableMapping, Protocol
+
+from ..state.positions import PositionsStore
+
+
+class FeedHandler(Protocol):
+    """Protocol describing the minimal feed handler contract."""
+
+    def stream(self) -> Iterable[tuple[Any, Mapping[str, float]]]:
+        """Yield (timestamp, minibatch) pairs in arrival order."""
+
+
+@dataclass
+class LatencyEvent:
+    """Metrics for a processed minibatch."""
+
+    timestamp: Any
+    elapsed_ms: float
+    dropped: bool = False
+
+
+class IntradayEngine:
+    """Run objective updates for streaming market data."""
+
+    def __init__(
+        self,
+        feed_handler: FeedHandler,
+        objective: Callable[[Mapping[str, float], Mapping[str, float]], MutableMapping[str, float]],
+        *,
+        state_store: PositionsStore | None = None,
+        latency_budget_ms: float = 50.0,
+        drop_overrun: bool = False,
+    ) -> None:
+        self._feed_handler = feed_handler
+        self._objective = objective
+        self._store = state_store
+        self.latency_budget_ms = latency_budget_ms
+        self.drop_overrun = drop_overrun
+        self.latency_events: list[LatencyEvent] = []
+        self._current_weights: Dict[str, float] = {}
+        if self._store is not None:
+            self._current_weights.update(self._store.load())
+
+    @property
+    def current_weights(self) -> Dict[str, float]:
+        """Return the latest portfolio weights."""
+
+        return dict(self._current_weights)
+
+    def _iter_feed(self) -> Iterator[tuple[Any, Mapping[str, float]]]:
+        stream = self._feed_handler.stream()
+        if isinstance(stream, Iterator):
+            return stream
+        return iter(stream)
+
+    def run(self) -> Dict[str, float]:
+        """Consume the entire feed and persist the final weights."""
+
+        for timestamp, minibatch in self._iter_feed():
+            warm_start = dict(self._current_weights)
+            start = time.perf_counter()
+            new_weights = self._objective(minibatch, warm_start)
+            elapsed_ms = (time.perf_counter() - start) * 1_000
+            dropped = bool(self.drop_overrun and elapsed_ms > self.latency_budget_ms)
+            self.latency_events.append(LatencyEvent(timestamp=timestamp, elapsed_ms=elapsed_ms, dropped=dropped))
+            if dropped:
+                continue
+            self._current_weights = dict(new_weights)
+            if self._store is not None:
+                self._store.save(self._current_weights)
+        return dict(self._current_weights)

--- a/neuro-ant-optimizer/src/neuro_ant_optimizer/live/__init__.py
+++ b/neuro-ant-optimizer/src/neuro_ant_optimizer/live/__init__.py
@@ -1,0 +1,5 @@
+"""Live trading bridges."""
+
+from .broker import OrderSubmission, SimulatedBroker, ThrottleError
+
+__all__ = ["OrderSubmission", "SimulatedBroker", "ThrottleError"]

--- a/neuro-ant-optimizer/src/neuro_ant_optimizer/live/broker.py
+++ b/neuro-ant-optimizer/src/neuro_ant_optimizer/live/broker.py
@@ -1,0 +1,79 @@
+"""Simulated broker bridge with idempotent order submission."""
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Dict, Mapping
+
+from ..state.positions import PositionsStore
+
+
+class ThrottleError(RuntimeError):
+    """Raised when submissions violate the throttle window."""
+
+
+@dataclass(frozen=True)
+class OrderSubmission:
+    """Representation of a target order request."""
+
+    symbol: str
+    target_weight: float
+    target_notional: float
+    client_order_id: str
+
+
+class SimulatedBroker:
+    """Paper broker that converts target weights into notionals."""
+
+    def __init__(
+        self,
+        *,
+        positions_store: PositionsStore,
+        throttle_window: float = 0.5,
+    ) -> None:
+        self._store = positions_store
+        self.throttle_window = throttle_window
+        self._last_submit_ts: float = 0.0
+        self._order_cache: dict[str, list[OrderSubmission]] = {}
+
+    def _check_throttle(self) -> None:
+        now = time.monotonic()
+        if now - self._last_submit_ts < self.throttle_window:
+            raise ThrottleError("order submissions throttled")
+        self._last_submit_ts = now
+
+    def submit_target_weights(
+        self,
+        target_weights: Mapping[str, float],
+        *,
+        account_value: float,
+        client_order_id: str,
+    ) -> list[OrderSubmission]:
+        """Submit target weights and persist resulting positions."""
+
+        if client_order_id in self._order_cache:
+            return self._order_cache[client_order_id]
+
+        self._check_throttle()
+        existing = self._store.load()
+        orders: list[OrderSubmission] = []
+        updated: Dict[str, float] = dict(existing)
+        for symbol, weight in target_weights.items():
+            target_notional = weight * account_value
+            orders.append(
+                OrderSubmission(
+                    symbol=symbol,
+                    target_weight=weight,
+                    target_notional=target_notional,
+                    client_order_id=client_order_id,
+                )
+            )
+            updated[symbol] = target_notional
+        self._store.save(updated)
+        self._order_cache[client_order_id] = orders
+        return orders
+
+    def load_positions(self) -> Dict[str, float]:
+        """Return the latest stored notionals."""
+
+        return self._store.load()

--- a/neuro-ant-optimizer/src/neuro_ant_optimizer/live/cli.py
+++ b/neuro-ant-optimizer/src/neuro_ant_optimizer/live/cli.py
@@ -1,0 +1,26 @@
+"""Console helper for running the simulated broker."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from ..state.positions import PositionsStore
+from .broker import SimulatedBroker
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Neuro Ant simulated broker")
+    parser.add_argument("--state", type=Path, required=True, help="Path to persist broker state")
+    parser.add_argument("--account", type=float, default=1_000_000.0, help="Account notional")
+    args = parser.parse_args(argv)
+
+    store = PositionsStore(args.state)
+    broker = SimulatedBroker(positions_store=store, throttle_window=0.0)
+    orders = broker.submit_target_weights({"CASH": 1.0}, account_value=args.account, client_order_id="boot")
+    print(json.dumps([order.__dict__ for order in orders], indent=2))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/neuro-ant-optimizer/src/neuro_ant_optimizer/scenario/__init__.py
+++ b/neuro-ant-optimizer/src/neuro_ant_optimizer/scenario/__init__.py
@@ -1,0 +1,5 @@
+"""Scenario and stress testing helpers."""
+
+from .runner import ScenarioConfig, ScenarioResult, ScenarioRunner
+
+__all__ = ["ScenarioConfig", "ScenarioResult", "ScenarioRunner"]

--- a/neuro-ant-optimizer/src/neuro_ant_optimizer/scenario/cli.py
+++ b/neuro-ant-optimizer/src/neuro_ant_optimizer/scenario/cli.py
@@ -1,0 +1,27 @@
+"""CLI for triggering simple scenario runs."""
+from __future__ import annotations
+
+import argparse
+import json
+
+from .runner import ScenarioConfig, ScenarioRunner
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Neuro Ant scenario runner")
+    parser.add_argument("--shock", type=float, default=0.0, help="Uniform return shock")
+    args = parser.parse_args(argv)
+
+    runner = ScenarioRunner([0.001, 0.0, -0.0005], transaction_cost=0.0001)
+    result = runner.run(ScenarioConfig(return_shock=args.shock))
+    payload = {
+        "adjusted_returns": result.adjusted_returns.tolist(),
+        "portfolio_path": result.portfolio_path.tolist(),
+        "breaches": result.breaches,
+    }
+    print(json.dumps(payload, indent=2))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/neuro-ant-optimizer/src/neuro_ant_optimizer/scenario/runner.py
+++ b/neuro-ant-optimizer/src/neuro_ant_optimizer/scenario/runner.py
@@ -1,0 +1,78 @@
+"""Scenario runner for applying structured shocks to return paths."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, List, Mapping
+
+import numpy as np
+
+
+@dataclass
+class ScenarioConfig:
+    """Configuration for a scenario stress test."""
+
+    return_shock: float = 0.0
+    vol_spike: float = 0.0
+    factor_tilts: Mapping[str, float] = field(default_factory=dict)
+    liquidity_haircut: float = 0.0
+    transaction_cost_multiplier: float = 1.0
+    breach_threshold: float | None = None
+
+
+@dataclass
+class ScenarioResult:
+    """Result from running a stress scenario."""
+
+    adjusted_returns: np.ndarray
+    portfolio_path: np.ndarray
+    breaches: List[str]
+
+
+class ScenarioRunner:
+    """Apply scenario shocks to a stream of returns."""
+
+    def __init__(
+        self,
+        base_returns: Iterable[float],
+        *,
+        factor_exposures: Mapping[str, float] | None = None,
+        transaction_cost: float = 0.0,
+        initial_value: float = 1.0,
+    ) -> None:
+        self._base_returns = np.asarray(list(base_returns), dtype=float)
+        self._factor_exposures = dict(factor_exposures or {})
+        self._transaction_cost = float(transaction_cost)
+        self._initial_value = float(initial_value)
+
+    def run(self, config: ScenarioConfig) -> ScenarioResult:
+        """Run a single scenario and compute the shocked P&L path."""
+
+        returns = self._base_returns.copy()
+        if config.return_shock:
+            returns = returns + config.return_shock
+        if config.vol_spike:
+            returns = returns * (1.0 + config.vol_spike)
+        if config.factor_tilts:
+            factor_contrib = sum(
+                tilt * self._factor_exposures.get(factor, 0.0)
+                for factor, tilt in config.factor_tilts.items()
+            )
+            if factor_contrib:
+                returns = returns + factor_contrib
+        if self._transaction_cost:
+            returns = returns - (self._transaction_cost * config.transaction_cost_multiplier)
+        path = self._compute_path(returns)
+        if config.liquidity_haircut:
+            path[-1] *= 1.0 - config.liquidity_haircut
+        breaches: List[str] = []
+        if config.breach_threshold is not None:
+            for idx, value in enumerate(path):
+                if value < config.breach_threshold:
+                    breaches.append(f"breach@{idx}")
+        return ScenarioResult(adjusted_returns=returns, portfolio_path=path, breaches=breaches)
+
+    def _compute_path(self, returns: np.ndarray) -> np.ndarray:
+        values = [self._initial_value]
+        for period_return in returns:
+            values.append(values[-1] * (1.0 + period_return))
+        return np.asarray(values[1:], dtype=float)

--- a/neuro-ant-optimizer/src/neuro_ant_optimizer/state/positions.py
+++ b/neuro-ant-optimizer/src/neuro_ant_optimizer/state/positions.py
@@ -1,0 +1,25 @@
+"""Simple JSON-backed position store used by multiple components."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, Mapping
+
+
+class PositionsStore:
+    """Persist and retrieve portfolio state."""
+
+    def __init__(self, path: str | Path) -> None:
+        self._path = Path(path)
+
+    def load(self) -> Dict[str, float]:
+        if not self._path.exists():
+            return {}
+        with self._path.open("r", encoding="utf-8") as handle:
+            raw = json.load(handle)
+        return {key: float(value) for key, value in raw.items()}
+
+    def save(self, positions: Mapping[str, float]) -> None:
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        with self._path.open("w", encoding="utf-8") as handle:
+            json.dump({key: float(value) for key, value in positions.items()}, handle, sort_keys=True)

--- a/neuro-ant-optimizer/tests/test_broker_sim.py
+++ b/neuro-ant-optimizer/tests/test_broker_sim.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from neuro_ant_optimizer.live.broker import SimulatedBroker, ThrottleError
+from neuro_ant_optimizer.state.positions import PositionsStore
+
+
+def test_simulated_broker_idempotent_orders(tmp_path):
+    store = PositionsStore(tmp_path / "positions.json")
+    broker = SimulatedBroker(positions_store=store, throttle_window=0.0)
+
+    first = broker.submit_target_weights(
+        {"AAPL": 0.6, "MSFT": 0.4}, account_value=1_000_000, client_order_id="order-1"
+    )
+    second = broker.submit_target_weights(
+        {"AAPL": 0.1}, account_value=1_000_000, client_order_id="order-1"
+    )
+
+    assert first == second
+    positions = broker.load_positions()
+    assert positions["AAPL"] == pytest.approx(600_000.0)
+    assert positions["MSFT"] == pytest.approx(400_000.0)
+
+
+def test_simulated_broker_throttles(tmp_path):
+    store = PositionsStore(tmp_path / "positions.json")
+    broker = SimulatedBroker(positions_store=store, throttle_window=0.01)
+
+    broker.submit_target_weights({"AAPL": 1.0}, account_value=100.0, client_order_id="order-a")
+
+    with pytest.raises(ThrottleError):
+        broker.submit_target_weights({"AAPL": 0.5}, account_value=100.0, client_order_id="order-b")
+
+    time.sleep(0.02)
+    broker.submit_target_weights({"AAPL": 0.5}, account_value=100.0, client_order_id="order-c")
+    assert broker.load_positions()["AAPL"] == pytest.approx(50.0)

--- a/neuro-ant-optimizer/tests/test_intraday_minibatch.py
+++ b/neuro-ant-optimizer/tests/test_intraday_minibatch.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Iterable, Mapping
+
+import pytest
+
+from neuro_ant_optimizer.intraday.engine import IntradayEngine
+from neuro_ant_optimizer.state.positions import PositionsStore
+
+
+@dataclass
+class DummyFeed:
+    payloads: Iterable[tuple[str, Mapping[str, float]]]
+
+    def stream(self) -> Iterable[tuple[str, Mapping[str, float]]]:
+        return iter(self.payloads)
+
+
+def test_intraday_engine_uses_warm_start(tmp_path):
+    store = PositionsStore(tmp_path / "positions.json")
+    store.save({"AAPL": 0.5})
+
+    batches = DummyFeed([
+        ("09:30", {"AAPL": 0.1, "MSFT": 0.2}),
+        ("09:31", {"AAPL": -0.05, "MSFT": 0.1}),
+    ])
+
+    warm_starts: list[Mapping[str, float]] = []
+
+    def objective(minibatch: Mapping[str, float], warm_start: Mapping[str, float]):
+        warm_starts.append(dict(warm_start))
+        updated = dict(warm_start)
+        for symbol, delta in minibatch.items():
+            updated[symbol] = warm_start.get(symbol, 0.0) + delta
+        return updated
+
+    engine = IntradayEngine(batches, objective, state_store=store)
+    result = engine.run()
+
+    assert warm_starts[0]["AAPL"] == pytest.approx(0.5)
+    assert result["AAPL"] == pytest.approx(0.55)
+    assert result["MSFT"] == pytest.approx(0.3)
+    persisted = store.load()
+    assert persisted["AAPL"] == pytest.approx(result["AAPL"])
+    assert persisted["MSFT"] == pytest.approx(result["MSFT"])
+
+
+def test_intraday_engine_drop_overrun(tmp_path):
+    store = PositionsStore(tmp_path / "positions.json")
+    store.save({"AAPL": 1.0})
+
+    batches = DummyFeed([("09:30", {"AAPL": -0.1})])
+
+    def slow_objective(minibatch: Mapping[str, float], warm_start: Mapping[str, float]):
+        time.sleep(0.005)
+        return {"AAPL": warm_start.get("AAPL", 0.0) + minibatch["AAPL"]}
+
+    engine = IntradayEngine(
+        batches,
+        slow_objective,
+        state_store=store,
+        latency_budget_ms=0.1,
+        drop_overrun=True,
+    )
+    result = engine.run()
+
+    assert result == {"AAPL": 1.0}
+    assert engine.latency_events[0].dropped is True
+    assert store.load() == {"AAPL": 1.0}

--- a/neuro-ant-optimizer/tests/test_scenarios.py
+++ b/neuro-ant-optimizer/tests/test_scenarios.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import numpy as np
+
+from neuro_ant_optimizer.scenario.runner import ScenarioConfig, ScenarioRunner
+
+
+def test_scenario_runner_applies_shocks():
+    base_returns = np.array([0.01, -0.005, 0.0])
+    runner = ScenarioRunner(
+        base_returns,
+        factor_exposures={"growth": 0.5},
+        transaction_cost=0.001,
+        initial_value=1.0,
+    )
+    config = ScenarioConfig(
+        return_shock=0.002,
+        vol_spike=0.1,
+        factor_tilts={"growth": 0.01},
+        liquidity_haircut=0.05,
+        transaction_cost_multiplier=2.0,
+        breach_threshold=0.96,
+    )
+
+    result = runner.run(config)
+
+    expected_returns = (base_returns + 0.002) * 1.1
+    expected_returns = expected_returns + 0.5 * 0.01
+    expected_returns = expected_returns - 0.001 * 2.0
+    assert np.allclose(result.adjusted_returns, expected_returns)
+
+    expected_path = []
+    value = 1.0
+    for r in expected_returns:
+        value *= 1.0 + r
+        expected_path.append(value)
+    expected_path[-1] *= 0.95
+    assert np.allclose(result.portfolio_path, expected_path)
+    assert result.breaches == []
+
+
+def test_scenario_runner_flags_breaches():
+    runner = ScenarioRunner([0.0, -0.05, -0.02], initial_value=1.0)
+    config = ScenarioConfig(return_shock=0.0, breach_threshold=0.97)
+    result = runner.run(config)
+    assert result.breaches == ["breach@1", "breach@2"]


### PR DESCRIPTION
## Summary
- add an intraday streaming engine with latency tracking and warm-start persistence
- implement a JSON-backed positions store and simulated broker with idempotent throttled order handling
- introduce scenario runner utilities with CLI entrypoints and coverage tests for new components

## Testing
- `pytest tests/test_intraday_minibatch.py tests/test_broker_sim.py tests/test_scenarios.py`

------
https://chatgpt.com/codex/tasks/task_e_68da6f7a540c833387fffaf589f570e5