### PR TITLE
Document optional test dependencies

### DIFF
--- a/neuro-ant-optimizer/docs/optimizer_behavior_report.md
+++ b/neuro-ant-optimizer/docs/optimizer_behavior_report.md
@@ -1,0 +1,37 @@
+# Optimizer and Backtest Behaviour Reference
+
+## Core Optimizer Defaults
+| Setting | Default | Notes |
+| --- | --- | --- |
+| `n_ants` | 16 | Colony width for the stochastic search phase.【F:src/neuro_ant_optimizer/optimizer.py†L28-L76】 |
+| `max_iter` | 20 | Total ant-colony iterations before convergence checks stop the loop.【F:src/neuro_ant_optimizer/optimizer.py†L28-L76】 |
+| `topk_refine` | 4 | Number of elite portfolios that are passed to SLSQP for deterministic polishing.【F:src/neuro_ant_optimizer/optimizer.py†L28-L76】 |
+| `refine_every` | 1 | Backtests request refinement on every window by default, so SLSQP receives candidates each rebalance unless overridden.【F:src/neuro_ant_optimizer/backtest/backtest.py†L3524-L3578】 |
+
+## Runtime Budgeting
+- `OptimizerConfig.max_runtime` defaults to two seconds and is enforced each optimization loop; exceeding the budget triggers an early exit with a runtime-budget message.【F:src/neuro_ant_optimizer/optimizer.py†L28-L76】【F:src/neuro_ant_optimizer/optimizer.py†L332-L374】
+
+## Refinement Scheduling and SLSQP Usage
+- The backtest toggles refinement by computing `should_refine = (len(weights) % refine_every) == 0`, so refinement only fires on windows that align with the `refine_every` cadence.【F:src/neuro_ant_optimizer/backtest/backtest.py†L4149-L4166】
+- Inside `NeuroAntPortfolioOptimizer.optimize`, the expensive SLSQP pass is wrapped in `_refine_topk` and is executed only when `refine=True`, ensuring SLSQP runs exclusively on the scheduled windows.【F:src/neuro_ant_optimizer/optimizer.py†L308-L318】【F:src/neuro_ant_optimizer/optimizer.py†L1092-L1239】
+
+## Behaviour When No Rebalances Occur
+- If no rebalance windows are available, the backtest returns empty arrays, attaches a `"no_rebalances"` warning, and still emits metadata such as constraint manifests and cov-cache stats.【F:src/neuro_ant_optimizer/backtest/backtest.py†L3898-L3957】
+- The rebalance report writer always outputs the full CSV header—including turnover, block-metric, and compliance audit columns (pre/post-trade flags, breach counts, and reason strings)—so a no-rebalance run yields a header-only `rebalance_report.csv` alongside the warning.【F:src/neuro_ant_optimizer/backtest/backtest.py†L5630-L5670】
+
+## Covariance Model Cache Keying
+- Covariance caching keys include the chosen model (or custom spec), sorted parameter items, EWMA span (when relevant), and a hash of the training window, preventing collisions between configurations.【F:src/neuro_ant_optimizer/backtest/backtest.py†L3547-L3548】【F:src/neuro_ant_optimizer/backtest/backtest.py†L3960-L4043】
+
+## Benchmark Metrics and Annualisation
+- Tracking error is annualised via `sqrt(trading_days)` inside `compute_tracking_error`, aligning TE/IR with the supplied trading-day count.【F:src/neuro_ant_optimizer/backtest/backtest.py†L1946-L1952】
+- Full-period metrics annualise active means and reuse the same TE helper, producing annualised info ratios for completed runs.【F:src/neuro_ant_optimizer/backtest/backtest.py†L4649-L4698】
+- Block-level summaries capture per-window Sharpe, Sortino, info ratio, and tracking error using the same annualisation factors, so CSVs and callbacks reflect consistent scaling.【F:src/neuro_ant_optimizer/backtest/backtest.py†L4460-L4528】
+
+## Risk-Free Parameterisation
+- CLI flag `--rf-bps` feeds into `risk_free_rate=float(parsed.rf_bps)/1e4`, with annualisation handled via `trading_days` to derive a per-period risk-free rate for Sharpe-like metrics.【F:src/neuro_ant_optimizer/backtest/backtest.py†L6513-L6527】【F:src/neuro_ant_optimizer/backtest/backtest.py†L3549-L3577】
+
+## Factor Alignment Modes and Diagnostics
+- Factor panels can be aligned in `strict` (default) or `subset` mode; strict mode demands exact date coverage, while subset mode drops missing dates/assets and tracks them in diagnostics.【F:src/neuro_ant_optimizer/backtest/backtest.py†L3289-L3358】【F:src/neuro_ant_optimizer/backtest/backtest.py†L3359-L3386】
+- `FactorDiagnostics` records dropped assets/dates and any rebalance windows that lack factor data, exposing counts plus sorted lists via `to_dict()`. Missing windows discovered during simulation are appended incrementally.【F:src/neuro_ant_optimizer/backtest/backtest.py†L589-L626】【F:src/neuro_ant_optimizer/backtest/backtest.py†L4141-L4143】
+- The CLI persists diagnostics as `factor_diagnostics.json` when present, making alignment issues visible in outputs.【F:src/neuro_ant_optimizer/backtest/backtest.py†L6748-L6763】
+

--- a/neuro-ant-optimizer/docs/reproducibility.md
+++ b/neuro-ant-optimizer/docs/reproducibility.md
@@ -31,3 +31,8 @@ Replay a run with `python -m neuro_ant_optimizer.backtest.reproduce --manifest r
 - Covariance caching (`--cache-cov`) defaults to `8`. Increase it when sliding windows overlap heavily; set it to `0` to force a cold path when benchmarking improvements.
 - Slippage and transaction-cost modelling add computation. Disable them when validating core optimization logic to minimize noise.
 - Use the new vectorized ant loop (enabled by default) to improve training throughput; benchmark scripts in `bench/` report wall-time improvements when compared to the previous per-ant PyTorch calls.
+
+## Optional test dependencies
+
+- `tests/test_drop_duplicates.py` imports pandas with `pytest.importorskip`, so the whole module is skipped when pandas is unavailable.【F:tests/test_drop_duplicates.py†L3-L58】
+- `tests/test_perf_parallel.py` exercises the multiprocessing backtest path only when pandas is installed; each test explicitly skips with a "pandas is required" message if the dependency is missing.【F:tests/test_perf_parallel.py†L1-L90】

--- a/neuro-ant-optimizer/tests/test_backtest_rebalance_report.py
+++ b/neuro-ant-optimizer/tests/test_backtest_rebalance_report.py
@@ -142,6 +142,14 @@ def test_rebalance_report_and_net_returns(tmp_path: Path, monkeypatch) -> None:
         assert record["block_sortino"] == pytest.approx(expected_block_sortino)
         assert record["block_info_ratio"] is None
         assert record["block_tracking_error"] is None
+        assert record["slippage_cost"] == pytest.approx(0.0)
+        assert record["pre_trade_ok"] is True
+        assert record["pre_trade_breach_count"] == 0
+        assert record["post_trade_breach_count"] == 0
+        assert record["breach_count"] == 0
+        assert record["first_breach"] is None
+        assert record["pre_trade_reasons"] == ""
+        assert record["post_trade_reasons"] == ""
         assert record["warm_applied"] is False
         assert record["decay"] == pytest.approx(0.0)
 
@@ -154,13 +162,45 @@ def test_rebalance_report_and_net_returns(tmp_path: Path, monkeypatch) -> None:
     report_path = tmp_path / "rebalance_report.csv"
     bt._write_rebalance_report(report_path, results)
     text = report_path.read_text().splitlines()
-    assert text[0] == (
-        "date,gross_ret,net_tx_ret,net_slip_ret,turnover,turnover_pre_decay,"
-        "turnover_post_decay,tx_cost,slippage_cost,nt_band_hits,participation_breaches,"
-        "sector_breaches,sector_penalty,active_breaches,group_breaches,factor_bound_breaches,"
-        "factor_inf_norm,factor_missing,first_violation,feasible,projection_iterations,block_sharpe,"
-        "block_sortino,block_info_ratio,block_tracking_error,warm_applied,decay"
+    expected_header = ",".join(
+        [
+            "date",
+            "gross_ret",
+            "net_tx_ret",
+            "net_slip_ret",
+            "turnover",
+            "turnover_pre_decay",
+            "turnover_post_decay",
+            "tx_cost",
+            "slippage_cost",
+            "nt_band_hits",
+            "participation_breaches",
+            "sector_breaches",
+            "sector_penalty",
+            "active_breaches",
+            "group_breaches",
+            "factor_bound_breaches",
+            "factor_inf_norm",
+            "factor_missing",
+            "first_violation",
+            "feasible",
+            "projection_iterations",
+            "block_sharpe",
+            "block_sortino",
+            "block_info_ratio",
+            "block_tracking_error",
+            "pre_trade_ok",
+            "pre_trade_breach_count",
+            "post_trade_breach_count",
+            "breach_count",
+            "first_breach",
+            "pre_trade_reasons",
+            "post_trade_reasons",
+            "warm_applied",
+            "decay",
+        ]
     )
+    assert text[0] == expected_header
 
 
 def test_active_bounds_fall_back_for_missing_benchmark(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- extend the reproducibility guide with a note about which tests require optional pandas support
- document the skip behaviour for the drop-duplicates and parallel backtest suites so the pytest summary is easier to interpret

## Testing
- pytest tests/test_backtest_rebalance_report.py -q
- pytest -vv *(interrupted after 7 tests passed and 2 skipped due to optional pandas dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68da83c044488333b00577b97f9b9fce