### PR TITLE
Enhance reproducibility tooling and CI coverage

### DIFF
--- a/neuro-ant-optimizer/.github/workflows/ci.yml
+++ b/neuro-ant-optimizer/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install numpy scipy torch pandas matplotlib pytest
       - name: Run determinism audit
-        run: pytest tests/test_backtest_cli_determinism.py
+        run: pytest -m slow
   test:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -33,6 +33,11 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "macos-latest"]
         python-version: ["3.9", "3.10", "3.11", "3.12"]
+        extras: [""]
+        include:
+          - os: ubuntu-latest
+            python-version: "3.11"
+            extras: "backtest"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -51,32 +56,35 @@ jobs:
           python -m pip install --upgrade pip
           pip install numpy scipy torch pytest pytest-cov build
           pip install ruff mypy pre-commit
-          # optional extras for CLI smoke
-          pip install pandas matplotlib
+          if [ "${{ matrix.extras }}" = "backtest" ]; then
+            pip install ".[backtest]"
+          else
+            pip install pandas matplotlib
+          fi
       - name: Pre-commit
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
         run: pre-commit run --all-files --show-diff-on-failure
       - name: Run tests
         run: |
           if [ "${{ matrix.os }}" = "ubuntu-latest" ] && [ "${{ matrix.python-version }}" = "3.11" ]; then
-            pytest --cov=neuro_ant_optimizer --cov-report=xml --cov-report=html --cov-fail-under=85
+            pytest --cov=neuro_ant_optimizer --cov-report=xml --cov-report=html --cov-fail-under=85 -m "not slow"
           else
-            pytest -q
+            pytest -q -m "not slow"
           fi
       - name: Upload coverage HTML
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11' && matrix.extras == ''
         uses: actions/upload-artifact@v4
         with:
           name: coverage-html-${{ matrix.python-version }}-${{ matrix.os }}
           path: htmlcov
       - name: mypy (types)
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11' && matrix.extras == ''
         env:
           MYPYPATH: neuro-ant-optimizer/src
         run: |
           mypy neuro-ant-optimizer/src
       - name: CLI smoke (backtest)
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11' && matrix.extras == ''
         run: |
           neuro-ant-optimizer/src/neuro_ant_optimizer/backtest/backtest.py >/dev/null 2>&1 || true
           python -c "import sys,subprocess; subprocess.check_call(['neuro-ant-backtest','--csv','neuro-ant-optimizer/backtest/sample_returns.csv','--lookback','5','--step','2','--ewma_span','3','--objective','sharpe','--out','neuro-ant-optimizer/backtest/out_ci'])"

--- a/neuro-ant-optimizer/CHANGELOG.md
+++ b/neuro-ant-optimizer/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.4.1
+- Covariance model extensions, benchmark objective tweaks, and risk-free handling refinements.
+- Expanded rebalance report schema with stability checks and fixture coverage.
+- Factor diagnostics polish plus parquet export path hardening.
+- Reproducibility tooling (manifest replayer, safety rails, CLI entry point) and determinism audits.
+- CI improvements with optional `[backtest]` leg, slow-test gating, and docs/code sync guards.
+
 ## 0.4.0
 - MkDocs documentation with quickstart, configuration reference, artifact schema, and reproducibility guide.
 - Deterministic CLI flag (`--deterministic`) with manifest tracking and strict Torch enforcement.

--- a/neuro-ant-optimizer/MANIFEST.in
+++ b/neuro-ant-optimizer/MANIFEST.in
@@ -1,0 +1,2 @@
+include README.md
+recursive-include docs *.md

--- a/neuro-ant-optimizer/Makefile
+++ b/neuro-ant-optimizer/Makefile
@@ -1,4 +1,8 @@
-.PHONY: quickstart
+.PHONY: quickstart test-all
 
 quickstart:
 	python scripts/quickstart.py
+
+test-all:
+	python -m pip install ".[backtest]"
+	pytest -q

--- a/neuro-ant-optimizer/README.md
+++ b/neuro-ant-optimizer/README.md
@@ -157,6 +157,16 @@ The command writes artifacts to `quickstart_artifacts/`, appends to `runs.csv`, 
 a zipped copy under `quickstart_archives/`. Inspect the outputs or open the example
 notebooks to explore the generated metrics.
 
+### Run the full test suite
+
+```bash
+pip install "neuro-ant-optimizer[backtest]"  # pulls pandas/mpl
+make test-all
+```
+
+> Some tests are skipped without pandas; installing the backtest extras enables those
+> scenarios locally.
+
 ---
 
 ## Streamlit artifact dashboard

--- a/neuro-ant-optimizer/docs/optimizer_behavior_report.md
+++ b/neuro-ant-optimizer/docs/optimizer_behavior_report.md
@@ -3,35 +3,35 @@
 ## Core Optimizer Defaults
 | Setting | Default | Notes |
 | --- | --- | --- |
-| `n_ants` | 16 | Colony width for the stochastic search phase.【F:src/neuro_ant_optimizer/optimizer.py†L28-L76】 |
-| `max_iter` | 20 | Total ant-colony iterations before convergence checks stop the loop.【F:src/neuro_ant_optimizer/optimizer.py†L28-L76】 |
-| `topk_refine` | 4 | Number of elite portfolios that are passed to SLSQP for deterministic polishing.【F:src/neuro_ant_optimizer/optimizer.py†L28-L76】 |
-| `refine_every` | 1 | Backtests request refinement on every window by default, so SLSQP receives candidates each rebalance unless overridden.【F:src/neuro_ant_optimizer/backtest/backtest.py†L3524-L3578】 |
+| `n_ants` | 16 | Colony width for the stochastic search phase (see `OptimizerConfig`). |
+| `max_iter` | 20 | Total ant-colony iterations before convergence checks stop the loop. |
+| `topk_refine` | 4 | Number of elite portfolios that are passed to SLSQP for deterministic polishing. |
+| `refine_every` | 1 | Backtests request refinement on every window by default, so SLSQP receives candidates each rebalance unless overridden. |
 
 ## Runtime Budgeting
-- `OptimizerConfig.max_runtime` defaults to two seconds and is enforced each optimization loop; exceeding the budget triggers an early exit with a runtime-budget message.【F:src/neuro_ant_optimizer/optimizer.py†L28-L76】【F:src/neuro_ant_optimizer/optimizer.py†L332-L374】
+- `OptimizerConfig.max_runtime` defaults to two seconds and is enforced each optimization loop; exceeding the budget triggers an early exit with a runtime-budget message.
 
 ## Refinement Scheduling and SLSQP Usage
-- The backtest toggles refinement by computing `should_refine = (len(weights) % refine_every) == 0`, so refinement only fires on windows that align with the `refine_every` cadence.【F:src/neuro_ant_optimizer/backtest/backtest.py†L4149-L4166】
-- Inside `NeuroAntPortfolioOptimizer.optimize`, the expensive SLSQP pass is wrapped in `_refine_topk` and is executed only when `refine=True`, ensuring SLSQP runs exclusively on the scheduled windows.【F:src/neuro_ant_optimizer/optimizer.py†L308-L318】【F:src/neuro_ant_optimizer/optimizer.py†L1092-L1239】
+- The backtest toggles refinement by computing `should_refine = (len(weights) % refine_every) == 0`, so refinement only fires on windows that align with the `refine_every` cadence.
+- Inside `NeuroAntPortfolioOptimizer.optimize`, the expensive SLSQP pass is wrapped in `_refine_topk` and is executed only when `refine=True`, ensuring SLSQP runs exclusively on the scheduled windows.
 
 ## Behaviour When No Rebalances Occur
-- If no rebalance windows are available, the backtest returns empty arrays, attaches a `"no_rebalances"` warning, and still emits metadata such as constraint manifests and cov-cache stats.【F:src/neuro_ant_optimizer/backtest/backtest.py†L3898-L3957】
-- The rebalance report writer always outputs the full CSV header—including turnover, block-metric, and compliance audit columns (pre/post-trade flags, breach counts, and reason strings)—so a no-rebalance run yields a header-only `rebalance_report.csv` alongside the warning.【F:src/neuro_ant_optimizer/backtest/backtest.py†L5630-L5670】
+- If no rebalance windows are available, the backtest returns empty arrays, attaches a `"no_rebalances"` warning, and still emits metadata such as constraint manifests and cov-cache stats.
+- The rebalance report writer always outputs the full CSV header—including turnover, block-metric, and compliance audit columns (pre/post-trade flags, breach counts, and reason strings)—so a no-rebalance run yields a header-only `rebalance_report.csv` alongside the warning.
 
 ## Covariance Model Cache Keying
-- Covariance caching keys include the chosen model (or custom spec), sorted parameter items, EWMA span (when relevant), and a hash of the training window, preventing collisions between configurations.【F:src/neuro_ant_optimizer/backtest/backtest.py†L3547-L3548】【F:src/neuro_ant_optimizer/backtest/backtest.py†L3960-L4043】
+- Covariance caching keys include the chosen model (or custom spec), sorted parameter items, EWMA span (when relevant), and a hash of the training window, preventing collisions between configurations.
 
 ## Benchmark Metrics and Annualisation
-- Tracking error is annualised via `sqrt(trading_days)` inside `compute_tracking_error`, aligning TE/IR with the supplied trading-day count.【F:src/neuro_ant_optimizer/backtest/backtest.py†L1946-L1952】
-- Full-period metrics annualise active means and reuse the same TE helper, producing annualised info ratios for completed runs.【F:src/neuro_ant_optimizer/backtest/backtest.py†L4649-L4698】
-- Block-level summaries capture per-window Sharpe, Sortino, info ratio, and tracking error using the same annualisation factors, so CSVs and callbacks reflect consistent scaling.【F:src/neuro_ant_optimizer/backtest/backtest.py†L4460-L4528】
+- Tracking error is annualised via `sqrt(trading_days)` inside `compute_tracking_error`, aligning TE/IR with the supplied trading-day count.
+- Full-period metrics annualise active means and reuse the same TE helper, producing annualised info ratios for completed runs.
+- Block-level summaries capture per-window Sharpe, Sortino, info ratio, and tracking error using the same annualisation factors, so CSVs and callbacks reflect consistent scaling.
 
 ## Risk-Free Parameterisation
-- CLI flag `--rf-bps` feeds into `risk_free_rate=float(parsed.rf_bps)/1e4`, with annualisation handled via `trading_days` to derive a per-period risk-free rate for Sharpe-like metrics.【F:src/neuro_ant_optimizer/backtest/backtest.py†L6513-L6527】【F:src/neuro_ant_optimizer/backtest/backtest.py†L3549-L3577】
+- CLI flag `--rf-bps` feeds into `risk_free_rate=float(parsed.rf_bps)/1e4`, with annualisation handled via `trading_days` to derive a per-period risk-free rate for Sharpe-like metrics.
 
 ## Factor Alignment Modes and Diagnostics
-- Factor panels can be aligned in `strict` (default) or `subset` mode; strict mode demands exact date coverage, while subset mode drops missing dates/assets and tracks them in diagnostics.【F:src/neuro_ant_optimizer/backtest/backtest.py†L3289-L3358】【F:src/neuro_ant_optimizer/backtest/backtest.py†L3359-L3386】
-- `FactorDiagnostics` records dropped assets/dates and any rebalance windows that lack factor data, exposing counts plus sorted lists via `to_dict()`. Missing windows discovered during simulation are appended incrementally.【F:src/neuro_ant_optimizer/backtest/backtest.py†L589-L626】【F:src/neuro_ant_optimizer/backtest/backtest.py†L4141-L4143】
-- The CLI persists diagnostics as `factor_diagnostics.json` when present, making alignment issues visible in outputs.【F:src/neuro_ant_optimizer/backtest/backtest.py†L6748-L6763】
+- Factor panels can be aligned in `strict` (default) or `subset` mode; strict mode demands exact date coverage, while subset mode drops missing dates/assets and tracks them in diagnostics.
+- `FactorDiagnostics` records dropped assets/dates and any rebalance windows that lack factor data, exposing counts plus sorted lists via `to_dict()`. Missing windows discovered during simulation are appended incrementally.
+- The CLI persists diagnostics as `factor_diagnostics.json` when present, making alignment issues visible in outputs.
 

--- a/neuro-ant-optimizer/docs/reproducibility.md
+++ b/neuro-ant-optimizer/docs/reproducibility.md
@@ -34,5 +34,5 @@ Replay a run with `python -m neuro_ant_optimizer.backtest.reproduce --manifest r
 
 ## Optional test dependencies
 
-- `tests/test_drop_duplicates.py` imports pandas with `pytest.importorskip`, so the whole module is skipped when pandas is unavailable.【F:tests/test_drop_duplicates.py†L3-L58】
-- `tests/test_perf_parallel.py` exercises the multiprocessing backtest path only when pandas is installed; each test explicitly skips with a "pandas is required" message if the dependency is missing.【F:tests/test_perf_parallel.py†L1-L90】
+- `tests/test_drop_duplicates.py` imports pandas with `pytest.importorskip`, so the whole module is skipped when pandas is unavailable.
+- `tests/test_perf_parallel.py` exercises the multiprocessing backtest path only when pandas is installed; each test explicitly skips with a "pandas is required" message if the dependency is missing.

--- a/neuro-ant-optimizer/pyproject.toml
+++ b/neuro-ant-optimizer/pyproject.toml
@@ -14,7 +14,7 @@ neuro_ant_optimizer = ["py.typed", "examples/configs/*.yaml"]
 
 [project]
 name = "neuro-ant-optimizer"
-version = "0.4.0"
+version = "0.4.1"
 description = "Neural-guided Ant Colony Portfolio Optimizer with robust constraints"
 readme = {file = "README.md", content-type = "text/markdown"}
 license = {text = "MIT"}
@@ -64,6 +64,7 @@ arrow = ["pyarrow>=15.0"]
 
 [project.scripts]
 neuro-ant-backtest = "neuro_ant_optimizer.backtest.backtest:main"
+neuro-ant-reproduce = "neuro_ant_optimizer.backtest.reproduce:main"
 neuro-ant-intraday = "neuro_ant_optimizer.intraday.cli:main"
 neuro-ant-sim = "neuro_ant_optimizer.live.cli:main"
 neuro-ant-scenario = "neuro_ant_optimizer.scenario.cli:main"

--- a/neuro-ant-optimizer/src/neuro_ant_optimizer/backtest/backtest.py
+++ b/neuro-ant-optimizer/src/neuro_ant_optimizer/backtest/backtest.py
@@ -5938,7 +5938,13 @@ def _extract_asset_names(frame: Any, n_assets: int) -> List[str]:
 def build_parser() -> argparse.ArgumentParser:
     """Construct the argument parser for the backtest CLI."""
 
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(
+        epilog=(
+            "If no rebalance windows remain after lookback/step alignment, the CLI "
+            "writes header-only reports and a 'no_rebalances' warning—adjust your "
+            "window length or input coverage to generate trades."
+        )
+    )
     parser.add_argument(
         "--config",
         type=str,
@@ -6018,8 +6024,8 @@ def build_parser() -> argparse.ArgumentParser:
         type=str,
         default="sample",
         help=(
-            "Covariance backend (sample|ewma|lw|oas|ridge|glasso|bayesian"
-            " or custom:<module>:<callable>; optional :param=value suffixes allowed)"
+            "Covariance estimator (sample|ewma|lw|oas|ridge|glasso|bayesian "
+            "or custom:module:callable[:param=value])"
         ),
     )
     parser.add_argument(
@@ -6145,13 +6151,13 @@ def build_parser() -> argparse.ArgumentParser:
         "--out-format",
         choices=["csv", "parquet"],
         default="csv",
-        help="Emit parquet artifacts alongside CSV outputs",
+        help="Artifact format to write (csv or parquet)",
     )
     parser.add_argument(
         "--rf-bps",
         type=float,
         default=0.0,
-        help="Annualized risk-free rate in basis points (default: 0)",
+        help="Annualised risk-free rate in basis points",
     )
     parser.add_argument(
         "--trading-days",
@@ -6260,7 +6266,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--factor-align",
         choices=["strict", "subset"],
         default="strict",
-        help="How to align factor panel dates with returns",
+        help="Align factor panel dates strictly or allow subset overlap",
     )
     parser.add_argument(
         "--factors-required",

--- a/neuro-ant-optimizer/tests/conftest.py
+++ b/neuro-ant-optimizer/tests/conftest.py
@@ -1,17 +1,78 @@
-"""
-Ensure `neuro_ant_optimizer` is importable when running pytest from the repo root
-without setting PYTHONPATH or doing an editable install.
-"""
+"""Pytest configuration helpers for the test suite."""
 from __future__ import annotations
 
+import json
 import sys
+from importlib import import_module
 from pathlib import Path
+from typing import Callable, List
+
+import pytest
 
 _HERE = Path(__file__).resolve()
-_PKG_ROOT = _HERE.parents[1]   # neuro-ant-optimizer/
+_PKG_ROOT = _HERE.parents[1]
 _SRC = _PKG_ROOT / "src"
 
 if _SRC.is_dir():
     p = str(_SRC)
     if p not in sys.path:
         sys.path.insert(0, p)
+
+bt = import_module("neuro_ant_optimizer.backtest.backtest")
+
+_EXPECTED_REBALANCE_HEADER: List[str] = [
+    "date",
+    "gross_ret",
+    "net_tx_ret",
+    "net_slip_ret",
+    "turnover",
+    "turnover_pre_decay",
+    "turnover_post_decay",
+    "tx_cost",
+    "slippage_cost",
+    "nt_band_hits",
+    "participation_breaches",
+    "sector_breaches",
+    "sector_penalty",
+    "active_breaches",
+    "group_breaches",
+    "factor_bound_breaches",
+    "factor_inf_norm",
+    "factor_missing",
+    "first_violation",
+    "feasible",
+    "projection_iterations",
+    "block_sharpe",
+    "block_sortino",
+    "block_info_ratio",
+    "block_tracking_error",
+    "pre_trade_ok",
+    "pre_trade_breach_count",
+    "post_trade_breach_count",
+    "breach_count",
+    "first_breach",
+    "pre_trade_reasons",
+    "post_trade_reasons",
+    "warm_applied",
+    "decay",
+]
+
+
+@pytest.fixture
+def assert_backtest_artifacts() -> Callable[[Path], List[str]]:
+    def _assert(path: Path) -> List[str]:
+        manifest_path = path / "run_config.json"
+        assert manifest_path.exists(), "run_config.json missing from backtest output"
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        assert (
+            manifest.get("schema_version") == bt.SCHEMA_VERSION
+        ), "schema version drift detected"
+
+        report_path = path / "rebalance_report.csv"
+        assert report_path.exists(), "rebalance_report.csv missing from backtest output"
+        header = report_path.read_text(encoding="utf-8").splitlines()[:1]
+        assert header, "rebalance_report.csv is empty"
+        assert header[0] == ",".join(_EXPECTED_REBALANCE_HEADER)
+        return list(_EXPECTED_REBALANCE_HEADER)
+
+    return _assert

--- a/neuro-ant-optimizer/tests/test_backtest_cli_determinism.py
+++ b/neuro-ant-optimizer/tests/test_backtest_cli_determinism.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from neuro_ant_optimizer.backtest.backtest import main as backtest_main
+
+pytestmark = pytest.mark.slow
 
 
 def _run_cli(out_dir: Path) -> None:

--- a/neuro-ant-optimizer/tests/test_backtest_config_manifest.py
+++ b/neuro-ant-optimizer/tests/test_backtest_config_manifest.py
@@ -25,7 +25,9 @@ class _StubOptimizer:
         return _Result(self.weight)
 
 
-def test_config_overrides_and_manifest(tmp_path: Path, monkeypatch) -> None:
+def test_config_overrides_and_manifest(
+    tmp_path: Path, monkeypatch, assert_backtest_artifacts
+) -> None:
     returns_path = tmp_path / "returns.csv"
     returns_path.write_text(
         "date,A,B\n"
@@ -77,3 +79,5 @@ def test_config_overrides_and_manifest(tmp_path: Path, monkeypatch) -> None:
     assert manifest["warm_start"] is None
     assert manifest["warm_align"] == "last_row"
     assert manifest["warm_applied_count"] == 0
+
+    assert_backtest_artifacts(out_dir)

--- a/neuro-ant-optimizer/tests/test_backtest_rebalance_report.py
+++ b/neuro-ant-optimizer/tests/test_backtest_rebalance_report.py
@@ -9,6 +9,7 @@ import numpy as np
 import pytest
 
 bt = import_module("neuro_ant_optimizer.backtest.backtest")
+from tests.conftest import _EXPECTED_REBALANCE_HEADER
 
 
 class _Frame:
@@ -162,44 +163,7 @@ def test_rebalance_report_and_net_returns(tmp_path: Path, monkeypatch) -> None:
     report_path = tmp_path / "rebalance_report.csv"
     bt._write_rebalance_report(report_path, results)
     text = report_path.read_text().splitlines()
-    expected_header = ",".join(
-        [
-            "date",
-            "gross_ret",
-            "net_tx_ret",
-            "net_slip_ret",
-            "turnover",
-            "turnover_pre_decay",
-            "turnover_post_decay",
-            "tx_cost",
-            "slippage_cost",
-            "nt_band_hits",
-            "participation_breaches",
-            "sector_breaches",
-            "sector_penalty",
-            "active_breaches",
-            "group_breaches",
-            "factor_bound_breaches",
-            "factor_inf_norm",
-            "factor_missing",
-            "first_violation",
-            "feasible",
-            "projection_iterations",
-            "block_sharpe",
-            "block_sortino",
-            "block_info_ratio",
-            "block_tracking_error",
-            "pre_trade_ok",
-            "pre_trade_breach_count",
-            "post_trade_breach_count",
-            "breach_count",
-            "first_breach",
-            "pre_trade_reasons",
-            "post_trade_reasons",
-            "warm_applied",
-            "decay",
-        ]
-    )
+    expected_header = ",".join(_EXPECTED_REBALANCE_HEADER)
     assert text[0] == expected_header
 
 

--- a/neuro-ant-optimizer/tests/test_backtest_sweep.py
+++ b/neuro-ant-optimizer/tests/test_backtest_sweep.py
@@ -6,7 +6,11 @@ from pathlib import Path
 import json
 from importlib import import_module
 
+import pytest
+
 bt = import_module("neuro_ant_optimizer.backtest.backtest")
+
+pytestmark = pytest.mark.slow
 
 
 def _write_returns(path: Path) -> None:

--- a/neuro-ant-optimizer/tests/test_optimizer_defaults_doc.py
+++ b/neuro-ant-optimizer/tests/test_optimizer_defaults_doc.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import re
+from importlib import import_module
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["n_ants", "max_iter", "topk_refine"],
+)
+def test_optimizer_defaults_synced_with_docs(field: str) -> None:
+    optimizer_mod = import_module("neuro_ant_optimizer.optimizer")
+    config = optimizer_mod.OptimizerConfig()
+    expected = getattr(config, field)
+
+    doc_path = Path("docs/optimizer_behavior_report.md")
+    text = doc_path.read_text(encoding="utf-8")
+    match = re.search(rf"\|\s+`{field}`\s+\|\s+([^|]+)\|", text)
+    assert match, f"Documentation missing row for {field}"
+    documented = match.group(1).strip()
+    assert str(expected) == documented, (
+        f"Documentation drift for {field}: expected {expected}, found {documented}"
+    )

--- a/neuro-ant-optimizer/tests/test_reproduce_cli.py
+++ b/neuro-ant-optimizer/tests/test_reproduce_cli.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+import sys
+from importlib import import_module
+from pathlib import Path
+
+import pytest
+
+bt = import_module("neuro_ant_optimizer.backtest.backtest")
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture(scope="session")
+def cli_env(tmp_path_factory: pytest.TempPathFactory) -> dict[str, str]:
+    bin_dir = tmp_path_factory.mktemp("cli-bin")
+    script_path = bin_dir / "neuro-ant-reproduce"
+    script_path.write_text(
+        f"#!{sys.executable}\n"
+        "import runpy\n"
+        "import sys\n"
+        "sys.exit(runpy.run_module('neuro_ant_optimizer.backtest.reproduce', run_name='__main__'))\n",
+        encoding="utf-8",
+    )
+    script_path.chmod(script_path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env.get('PATH', '')}"
+    src_path = str(PROJECT_ROOT / "src")
+    existing = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = f"{src_path}{os.pathsep}{existing}" if existing else src_path
+    return env
+
+
+def test_reproduce_console_script(
+    tmp_path: Path, cli_env: dict[str, str], assert_backtest_artifacts
+) -> None:
+    returns_path = tmp_path / "returns.csv"
+    returns_path.write_text(
+        "date,A,B\n"
+        "2020-01-01,0.01,0.00\n"
+        "2020-01-02,0.02,-0.01\n"
+        "2020-01-03,0.00,0.01\n"
+        "2020-01-04,0.01,0.02\n"
+        "2020-01-05,0.02,0.01\n",
+        encoding="utf-8",
+    )
+
+    out_dir = tmp_path / "orig"
+    bt.main(
+        [
+            "--csv",
+            str(returns_path),
+            "--lookback",
+            "3",
+            "--step",
+            "2",
+            "--out",
+            str(out_dir),
+            "--skip-plot",
+        ]
+    )
+
+    manifest_path = out_dir / "run_config.json"
+    assert manifest_path.exists()
+    manifest_blob = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest_blob["args"]["max_iter"] = 2
+    manifest_blob["args"]["n_ants"] = 4
+    manifest_path.write_text(json.dumps(manifest_blob), encoding="utf-8")
+
+    replay_dir = tmp_path / "replay"
+    subprocess.check_call(
+        [
+            "neuro-ant-reproduce",
+            "--manifest",
+            str(manifest_path),
+            "--out",
+            str(replay_dir),
+        ],
+        cwd=PROJECT_ROOT,
+        env=cli_env,
+    )
+
+    assert (replay_dir / "equity.csv").exists()
+    assert_backtest_artifacts(replay_dir)
+
+
+def test_reproduce_missing_inputs(tmp_path: Path, cli_env: dict[str, str]) -> None:
+    manifest = {
+        "schema_version": bt.SCHEMA_VERSION,
+        "args": {
+            "csv": "backtest/missing.csv",
+            "lookback": 5,
+            "step": 2,
+        },
+    }
+    manifest_path = tmp_path / "run_config.json"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    out_dir = tmp_path / "out"
+    proc = subprocess.run(
+        [
+            "neuro-ant-reproduce",
+            "--manifest",
+            str(manifest_path),
+            "--out",
+            str(out_dir),
+        ],
+        capture_output=True,
+        text=True,
+        cwd=PROJECT_ROOT,
+        env=cli_env,
+    )
+    assert proc.returncode != 0
+    output = proc.stdout + proc.stderr
+    assert "Manifest references missing inputs" in output
+    assert "missing.csv" in output

--- a/neuro-ant-optimizer/tests/test_reproduce_cli.py
+++ b/neuro-ant-optimizer/tests/test_reproduce_cli.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 import os
-import stat
 import subprocess
 import sys
 from importlib import import_module
@@ -13,23 +12,20 @@ import pytest
 bt = import_module("neuro_ant_optimizer.backtest.backtest")
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
+CLI_BOOTSTRAP = (
+    "import runpy,sys;"
+    "sys.argv=['neuro-ant-reproduce']+sys.argv[1:];"
+    "sys.exit(runpy.run_module('neuro_ant_optimizer.backtest.reproduce', run_name='__main__'))"
+)
+
+
+def _cli_args(*args: str) -> list[str]:
+    return [sys.executable, "-c", CLI_BOOTSTRAP, *args]
 
 
 @pytest.fixture(scope="session")
-def cli_env(tmp_path_factory: pytest.TempPathFactory) -> dict[str, str]:
-    bin_dir = tmp_path_factory.mktemp("cli-bin")
-    script_path = bin_dir / "neuro-ant-reproduce"
-    script_path.write_text(
-        f"#!{sys.executable}\n"
-        "import runpy\n"
-        "import sys\n"
-        "sys.exit(runpy.run_module('neuro_ant_optimizer.backtest.reproduce', run_name='__main__'))\n",
-        encoding="utf-8",
-    )
-    script_path.chmod(script_path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
-
+def cli_env() -> dict[str, str]:
     env = os.environ.copy()
-    env["PATH"] = f"{bin_dir}{os.pathsep}{env.get('PATH', '')}"
     src_path = str(PROJECT_ROOT / "src")
     existing = env.get("PYTHONPATH")
     env["PYTHONPATH"] = f"{src_path}{os.pathsep}{existing}" if existing else src_path
@@ -74,13 +70,7 @@ def test_reproduce_console_script(
 
     replay_dir = tmp_path / "replay"
     subprocess.check_call(
-        [
-            "neuro-ant-reproduce",
-            "--manifest",
-            str(manifest_path),
-            "--out",
-            str(replay_dir),
-        ],
+        _cli_args("--manifest", str(manifest_path), "--out", str(replay_dir)),
         cwd=PROJECT_ROOT,
         env=cli_env,
     )
@@ -103,13 +93,7 @@ def test_reproduce_missing_inputs(tmp_path: Path, cli_env: dict[str, str]) -> No
 
     out_dir = tmp_path / "out"
     proc = subprocess.run(
-        [
-            "neuro-ant-reproduce",
-            "--manifest",
-            str(manifest_path),
-            "--out",
-            str(out_dir),
-        ],
+        _cli_args("--manifest", str(manifest_path), "--out", str(out_dir)),
         capture_output=True,
         text=True,
         cwd=PROJECT_ROOT,

--- a/neuro-ant-optimizer/tests/test_service_e2e.py
+++ b/neuro-ant-optimizer/tests/test_service_e2e.py
@@ -7,6 +7,8 @@ from fastapi.testclient import TestClient
 
 from service.app import create_app
 
+pytestmark = pytest.mark.slow
+
 
 @pytest.fixture()
 def client(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- guard documentation defaults with a new unit test and remove brittle line anchors
- expose the reproduce helper as a console script, add missing-input safety rails, and smoke-test the CLI
- document optional test extras, add a test-all make target, include docs in sdists, and gate slow jobs in CI with a backtest extras leg
- bump the project to 0.4.1 with a changelog entry and add parser help/epilog improvements

## Testing
- `pytest tests/test_optimizer_defaults_doc.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68daa3ac9d608333a65f4f3a5a7ee1aa