### PR TITLE
Fix timezone warning when comparing now

### DIFF
--- a/neuro-ant-optimizer/src/neuro_ant_optimizer/data/loader.py
+++ b/neuro-ant-optimizer/src/neuro_ant_optimizer/data/loader.py
@@ -262,7 +262,9 @@ def load_returns(
         last_dt = aligned_index[-1]
         tzinfo = normalize_timezone(tz)
         now_val = datetime.now(tzinfo)
-        now_cmp = np.datetime64(now_val.astimezone(UTC))
+        # Represent as UTC epoch nanoseconds to avoid timezone-aware -> naive warnings
+        _ns = int(now_val.astimezone(UTC).timestamp() * 1e9)
+        now_cmp = np.datetime64(_ns, "ns")
         if np.datetime64(last_dt) > now_cmp:
             raise PITViolationError(
                 f"Last observation {last_dt} is in the future relative to timezone {tz or 'UTC'}"


### PR DESCRIPTION
## Summary
- avoid constructing timezone-naive numpy datetime values from timezone-aware datetimes
- convert the current time to UTC epoch nanoseconds before creating the numpy datetime64 comparison value

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dae214e08883338f73f8a478e2af7f