### PR TITLE
Fix pytest import and silence TestClient warnings

### DIFF
--- a/neuro-ant-optimizer/pyproject.toml
+++ b/neuro-ant-optimizer/pyproject.toml
@@ -74,6 +74,9 @@ addopts = "-q"
 markers = [
   "slow: tests that cover multiprocessing or longer running behaviour",
 ]
+filterwarnings = [
+  "ignore:cannot collect test class 'TestClient' because it has a __init__ constructor:pytest.PytestCollectionWarning",
+]
 
 [tool.ruff]
 line-length = 100

--- a/neuro-ant-optimizer/tests/test_backtest_rebalance_report.py
+++ b/neuro-ant-optimizer/tests/test_backtest_rebalance_report.py
@@ -9,7 +9,7 @@ import numpy as np
 import pytest
 
 bt = import_module("neuro_ant_optimizer.backtest.backtest")
-from tests.conftest import _EXPECTED_REBALANCE_HEADER
+from conftest import _EXPECTED_REBALANCE_HEADER
 
 
 class _Frame:


### PR DESCRIPTION
## Summary
- adjust the backtest rebalance report test to import constants directly from `conftest`
- silence the harmless pytest collection warning emitted by FastAPI's `TestClient`

## Testing
- `pytest -q` *(fails: interrupted due to long runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68dae03663b08333a887282a2cff2199