### PR TITLE
Release v0.4.2

### DIFF
--- a/neuro-ant-optimizer/.github/workflows/ci.yml
+++ b/neuro-ant-optimizer/.github/workflows/ci.yml
@@ -86,6 +86,8 @@ jobs:
       - name: CLI smoke (backtest)
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11' && matrix.extras == ''
         run: |
+          neuro-ant-backtest --help >/dev/null
+          neuro-ant-reproduce --help >/dev/null
           neuro-ant-optimizer/src/neuro_ant_optimizer/backtest/backtest.py >/dev/null 2>&1 || true
           python -c "import sys,subprocess; subprocess.check_call(['neuro-ant-backtest','--csv','neuro-ant-optimizer/backtest/sample_returns.csv','--lookback','5','--step','2','--ewma_span','3','--objective','sharpe','--out','neuro-ant-optimizer/backtest/out_ci'])"
       - name: Build wheel
@@ -103,6 +105,13 @@ jobs:
           path: dist/*.whl
   slow-checks:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      PYTHONHASHSEED: "0"
+      OMP_NUM_THREADS: "1"
+      MKL_NUM_THREADS: "1"
+      NUMEXPR_NUM_THREADS: "1"
+      OPENBLAS_NUM_THREADS: "1"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -125,7 +134,7 @@ jobs:
     name: release build
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [test]
+    needs: [test, slow-checks]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/neuro-ant-optimizer/.pre-commit-config.yaml
+++ b/neuro-ant-optimizer/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.5.6
+    rev: v0.6.9
     hooks:
       - id: ruff
         args: [--force-exclude]

--- a/neuro-ant-optimizer/CHANGELOG.md
+++ b/neuro-ant-optimizer/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.4.2
+- Deterministic slow-check harness with tightened CI timeouts and CLI smoke coverage.
+- README polish covering reproducibility commands plus links to the in-depth guides.
+- Packaging and tooling refresh ahead of the v0.4.2 wheel release.
+
 ## 0.4.1
 - Covariance model extensions, benchmark objective tweaks, and risk-free handling refinements.
 - Expanded rebalance report schema with stability checks and fixture coverage.

--- a/neuro-ant-optimizer/MANIFEST.in
+++ b/neuro-ant-optimizer/MANIFEST.in
@@ -1,2 +1,3 @@
 include README.md
 recursive-include docs *.md
+recursive-include scripts *.py

--- a/neuro-ant-optimizer/README.md
+++ b/neuro-ant-optimizer/README.md
@@ -157,6 +157,15 @@ The command writes artifacts to `quickstart_artifacts/`, appends to `runs.csv`, 
 a zipped copy under `quickstart_archives/`. Inspect the outputs or open the example
 notebooks to explore the generated metrics.
 
+### Replay a recorded manifest
+
+```bash
+neuro-ant-reproduce --manifest runs/.../run_config.json --out bt_out_replay
+```
+
+The reproducibility CLI replays a captured configuration manifest and regenerates the
+backtest artifacts under the directory provided via `--out`.
+
 ### Run the full test suite
 
 ```bash
@@ -166,6 +175,15 @@ make test-all
 
 > Some tests are skipped without pandas; installing the backtest extras enables those
 > scenarios locally.
+
+### Slow checks
+
+The long-running regression harness that mirrors CI coverage lives in
+[`docs/slow_test_guide.md`](docs/slow_test_guide.md). For deeper determinism guidance and a
+full walkthrough of manifest replay tooling, see the
+[`docs/reproducibility.md`](docs/reproducibility.md) companion guide. Both references
+explain the scenarios, expected artifacts, and tips for reproducing the checks locally
+before pushing.
 
 ---
 

--- a/neuro-ant-optimizer/pyproject.toml
+++ b/neuro-ant-optimizer/pyproject.toml
@@ -14,7 +14,7 @@ neuro_ant_optimizer = ["py.typed", "examples/configs/*.yaml"]
 
 [project]
 name = "neuro-ant-optimizer"
-version = "0.4.1"
+version = "0.4.2"
 description = "Neural-guided Ant Colony Portfolio Optimizer with robust constraints"
 readme = {file = "README.md", content-type = "text/markdown"}
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary
- bump to v0.4.2 with changelog updates and README instructions for manifest replays
- tighten slow-checks runtime and extend CI smoke coverage with CLI help checks
- refresh pre-commit hook revisions ahead of the tagged release

## Testing
- python -m pip wheel . --no-deps --no-build-isolation
- pip install --no-deps dist/neuro_ant_optimizer-0.4.2-py3-none-any.whl
- neuro-ant-backtest --help
- neuro-ant-reproduce --help

------
https://chatgpt.com/codex/tasks/task_e_68db680ceec883338de0ecf7db824a46